### PR TITLE
docs: add game logic subsystem architecture documentation (7 files)

### DIFF
--- a/analysis/AI_SYSTEM_ARCHITECTURE.md
+++ b/analysis/AI_SYSTEM_ARCHITECTURE.md
@@ -1,0 +1,233 @@
+# AI System Architecture — Virtua Racing Deluxe (32X)
+
+## 1. Overview
+
+The AI system controls opponent vehicles using a **15-state machine** with timer-based advancement, **3-band Manhattan distance collision avoidance**, and a **4-band distance-based approach ramp** for spawn-to-active transitions.
+
+**27 modules** in `disasm/modules/68k/game/ai/`, ~2.5KB total code.
+
+**Key characteristics:**
+- 15-state machine at `$FFA0EA` (120-frame timer per state, cyclic 3-phase pattern)
+- Manhattan distance (|dX|+|dY|) for all proximity — cheap to compute on 68K
+- `collision_avoidance_speed_calc` falls through directly to `physics_integration` (no RTS)
+- atan2 approximation for heading computation
+- 4-slot race position system with spawn/active/retire lifecycle
+
+---
+
+## 2. AI Entity Lifecycle
+
+### 2.1 Race Slot System
+
+4 slots managed via table at RAM `$FFC03C`:
+
+| State | Value | Meaning |
+|-------|-------|---------|
+| Empty | 0 | Slot available |
+| Finished | 1 | Entity completed race |
+| Ready | 2 | Assigned, not yet spawned |
+| Active | 3 | Entity racing |
+| Retiring | 4 | Fade-out in progress |
+
+### 2.2 Spawn Phase
+
+`ai_entity_main_update_orch` ($00A972) manages the spawn sequence:
+
+1. **Target lookup:** Reads spawn target from slot/difficulty tables
+2. **Visibility ramp:** `visibility = (120 - timer) × $3BBB >> 16`
+3. **Race state trigger:** At visibility=20, calls `race_state_read`
+4. **Activation:** When timer expires, advances slot to state 3 (active)
+
+### 2.3 4-Band Approach Ramp
+
+Distance from spawn point to target position determines approach speed:
+
+| Band | Distance | Speed | Y Offset |
+|------|----------|-------|----------|
+| 1 | <128 | $20 (slow) | 0 |
+| 2 | 128-384 | `dist×3/16 + 8` | -64 |
+| 3 | 384-1024 | `dist/8 + $20` | -128 |
+| 4 | >1024 | `dist/16 + $64` (max 200) | -128 |
+
+### 2.4 Retirement
+
+Scans slot table for reorder opportunities (lower slots with state==1, upper slots with state==4), then retires entity, clearing slot.
+
+---
+
+## 3. State Machine
+
+**Dispatch:** `ai_state_dispatch` at $00BE50 (116 bytes)
+**State variable:** `$FFA0EA` (word, steps by 4)
+**Timer variable:** `$FFA0EC` (word)
+
+15-entry jump table. Entry 0 is the timer handler (counts to 120 frames, then advances state by 4, resets timer). Entries 1-13 form a **repeating 3-phase cycle**:
+
+```
+Entries 2, 5, 8, 11 → Phase A handler
+Entries 3, 6, 9, 12 → Phase B handler
+Entries 4, 7, 10, 13 → Phase C handler
+Entry 14 → Terminal state
+```
+
+State advance: `addq.w #4,($A0EA).w` + `clr.w ($A0EC).w`
+(Two identical copies at $BFD4 and $C01E)
+
+---
+
+## 4. Steering System
+
+### 4.1 atan2 Approximation (`ai_steering_calc`, $00A7A0)
+
+```
+DX = target_x - entity_x
+DY = target_y - entity_y
+
+if DY == 0: return ±$4000 (90 degrees)
+
+ratio = (DX × 256) / DY         // fixed-point tangent
+angle = atan2_lookup(ratio)      // table-based
+return 16-bit angle ($0000-$FFFF = full circle)
+```
+
+Shared by AI, physics, and camera subsystems.
+
+Source: [ai_steering_calc.asm](disasm/modules/68k/game/ai/ai_steering_calc.asm)
+
+### 4.2 Heading Convergence
+
+```
+heading_delta = (target_heading - current_heading) / steering_factor
+heading += heading_delta
+```
+
+- `steering_factor` = `max(1, frames_to_target / 2)` — longer distances use gentler steering
+- Override: if `+$54` bit 0 set, force `steering_factor = 2`
+- Convergence rate: 1/4 per frame (`ASR.W #2`)
+
+### 4.3 Turn Rate Clamping
+
+- Maximum: +/-$140 per frame
+- Dead zone: heading zeroed if |heading| < $100 (prevents oscillation)
+
+---
+
+## 5. Collision Avoidance
+
+`collision_avoidance_speed_calc` ($00A470, 502 bytes) — the primary AI combat logic.
+
+**Critical:** This function has **no RTS** — it falls through directly to `physics_integration` at $A666.
+
+Source: [collision_avoidance_speed_calc.asm](disasm/modules/68k/game/ai/collision_avoidance_speed_calc.asm)
+
+### 5.1 Speed Computation ($A470-$A4AC)
+
+Loads entity data pointer (+$18), computes speed from table index (+$24) with modifier from speed table at `$C280`. Default speed = 150 ($96).
+
+### 5.2 Proximity Gate ($A4AE)
+
+Tests bit 1 of +$55 (collision flag). If clear → skip avoidance, go directly to `physics_integration`.
+
+### 5.3 Primary Target Avoidance ($A4EC-$A580)
+
+Three distance bands using Manhattan distance (|dX|+|dY|):
+
+| Band | Threshold | Steering Response | Speed Response |
+|------|-----------|-------------------|----------------|
+| Close | <160 | If |dZ|<64: force = `(64 - |dZ|) × 6` | Braking at |dZ|<48 |
+| Medium | 160-320 | Speed-dependent scaling | — |
+| Approach | <112 (heading) | Heading correction (halve delta) | — |
+
+Track-specific scaling: track 28 uses ×9 instead of default ×6 for steering force.
+
+### 5.4 Secondary Entity Path ($A582-$A664)
+
+Follows target's own target chain (+$A4 → +$A4). Different thresholds:
+- Manhattan < 480: speed-based braking `(480 - dist) >> variable_shift`
+- |dZ| < 64: lateral steering ×4 multiplier
+
+### 5.5 No-Target Fallback (`collision_avoidance_no_target`, $A6F8)
+
+Uses player entity at $9000 as reference:
+- Manhattan threshold: $230 (560 units)
+- Lateral threshold: $40-$70
+- Steering force: `(96 - |dZ|) × 24`
+- Exits via `BRA.W physics_integration`
+
+---
+
+## 6. Opponent Selection (`ai_opponent_select`, $A434)
+
+**Activation gates:**
+- Game mode `$C8C8` != 1
+- Speed index >= $59 (89)
+- Game state == 4
+- 15-frame cooldown at +$86
+
+**Categories:**
+- Normal: speed < 200
+- High-speed: speed >= $C8 (200) → sets opponent category flag +$BE = 1
+
+Triggers AI behavior byte $B7 in `$C8A4`.
+
+Source: [ai_opponent_select.asm](disasm/modules/68k/game/ai/ai_opponent_select.asm)
+
+---
+
+## 7. Scene Interpolation (`ai_scene_interpolation`, $BD2A)
+
+6-component keyframe blending for attract/replay mode:
+
+Interpolates position (X, Y, Z), heading, speed, and camera angle between two keyframes. Linear interpolation with per-component delta scaling.
+
+Source: [ai_scene_interpolation.asm](disasm/modules/68k/game/ai/ai_scene_interpolation.asm)
+
+---
+
+## 8. Speed Conversion
+
+AI orchestrator converts distance-based speed to game units:
+
+```
+game_speed = distance_speed × 1000 × 256 / 3600 / 20
+```
+
+Per-frame acceleration clamped to: +$2F (47) acceleration, -$50 (80) deceleration.
+
+---
+
+## 9. Cross-Subsystem Interfaces
+
+### AI → Physics (Fall-Through)
+
+`collision_avoidance_speed_calc` ($A470) has **no RTS** at its end. All exit paths flow into `physics_integration` ($A666), which computes heading via `ai_steering_calc`, integrates position via sin/cos × speed >> 12, and updates +$30/+$34.
+
+### Shared Functions
+
+| Function | Address | Used By |
+|----------|---------|---------|
+| `ai_steering_calc` | $A7A0 | AI, Physics, Camera |
+| `sine_cosine_quadrant_lookup` | $8F4E | All subsystems |
+| `entity_speed_clamp` | $9B12 | AI orchestrator, Physics pipeline |
+| `entity_force_integration+18` | $9312 | AI orchestrator (tail-call) |
+| `entity_pos_update+70` | $7008 | AI orchestrator (position integration) |
+
+### Entity Fields (AI-Specific)
+
+| Offset | Size | Name | Purpose |
+|--------|------|------|---------|
+| +$A4 | word | target_index_1 | Primary target entity index |
+| +$A6 | word | target_index_2 | Secondary target |
+| +$AE | word | slot_index | Race slot (0-3) |
+| +$B0 | word | spawn_timer | Countdown (120 frames) |
+| +$BC | word | decel_accum | Deceleration accumulator |
+| +$BE | word | opponent_category | 0=normal, 1=high-speed |
+
+### Global AI RAM
+
+| Address | Purpose |
+|---------|---------|
+| `$FFA0EA` | AI state (jump table index, 0-56) |
+| `$FFA0EC` | AI timer (counts to 120) |
+| `$FFC8AA` | Scene state (interpolation counter) |
+| `$FFC03C` | Race slot table base (4 slots) |

--- a/analysis/COLLISION_SYSTEM_ARCHITECTURE.md
+++ b/analysis/COLLISION_SYSTEM_ARCHITECTURE.md
@@ -1,0 +1,276 @@
+# Collision System Architecture — Virtua Racing Deluxe (32X)
+
+## 1. Overview
+
+The collision system handles three distinct subsystems: **track boundary detection** (center + 4-probe with binary search response), **object-to-object collision** (weighted speed averaging), and **proximity zones** (4-level Manhattan distance classification).
+
+**23 modules** in `disasm/modules/68k/game/collision/`, ~3KB total code.
+
+**Key characteristics:**
+- 4-iteration binary search resolves collision to 1/4-frame precision
+- EMA surface tracking: `new = (old + height) / 2` for temporal smoothing
+- Manhattan distance (|dX|+|dY|) throughout — no Euclidean distance
+- 4-level proximity zones with bit-15 flag for critical proximity
+- Called from `entity_pos_update` via JMP (no RTS boundary from physics)
+
+---
+
+## 2. Track Boundary Collision
+
+### 2.1 5-Point Probe System (`track_boundary_collision_detection`, $789C)
+
+**ROM:** $00789C-$007A40 (420 bytes)
+**Source:** [track_boundary_collision_detection.asm](disasm/modules/68k/game/collision/track_boundary_collision_detection.asm)
+
+Probes 5 points per frame: center + 4 directional offsets.
+
+**Center probe:**
+1. Computes heading + scale from entity fields
+2. Extracts track geometry via `track_data_extract_033` (4-page, work buffer at $C02E)
+3. Tile lookup via `track_data_index_calc_table_lookup`
+4. Stores tile data pointer in +$CE, surface type byte, probe coordinates
+
+**4 directional probes** (front-left, front-right, rear-left, rear-right):
+1. Adds pre-computed offset from RAM (negative word addresses -16338 through -16316) to entity position
+2. Performs tile lookup
+3. **Same-tile optimization:** If same tile as center (compare A1 pointers), tries fast boundary check (`angle_normalize+168`) first, then full check (`angle_normalize+24`). Avoids redundant tile lookups.
+4. On collision: stores tile pointer (+$D2/+$D6/+$DA/+$DE), classifies surface via `object_type_dispatch`, stores per-probe flag (+$56/+$57/+$58/+$59)
+
+**Flag combination:** Final = `probe1 | probe2 | probe3 | probe4` → +$55
+
+**Callers:** `collision_response_surface_tracking` (up to 5 calls during binary search)
+
+---
+
+## 3. Binary Search Response (`collision_response_surface_tracking`, $7700)
+
+**ROM:** $007700-$00789C (412 bytes)
+**Source:** [collision_response_surface_tracking.asm](disasm/modules/68k/game/collision/collision_response_surface_tracking.asm)
+
+The most sophisticated algorithm in the collision system. Resolves the precise collision point via **4-iteration binary search**.
+
+### Algorithm
+
+```
+1. INITIAL DETECTION:
+   Call track_boundary_collision_detection (5-probe)
+   If collision active (+$62 > 0) OR any probe hit (+$55 bit 0):
+     → enter binary search
+
+2. COMPUTE 1/4 DELTAS:
+   For heading(+$40), scale(+$46), X(+$30), Y(+$34):
+     delta = (current - previous) / 4
+
+3. RESET TO PREVIOUS FRAME:
+   Restore all 4 values from previous-frame snapshots (+$42, +$48, +$36, +$38)
+
+4. BINARY SEARCH (4 iterations):
+   for i = 0..3:
+     advance by 1/4 step
+     call track_boundary_collision_detection
+     if +$55 bit 0 set (collision):
+       revert last 1/4 step
+       break
+
+5. SNAPSHOT:
+   Save current values as previous for next frame
+
+6. SURFACE TRACKING (EMA):
+   For 4 probe points:
+     height = plane_eval(probe_position)
+     probe_height = (old_height + height) / 2    // alpha = 0.5
+   Store: +$5A, +$5C, +$5E (probe heights), +$32 (center height)
+```
+
+### Fields Rolled Back During Search
+
+| Field | Current | Previous | Delta |
+|-------|---------|----------|-------|
+| Heading | +$40 | +$42 | (current-prev)/4 |
+| Scale | +$46 | +$48 | (current-prev)/4 |
+| X position | +$30 | +$36 | (current-prev)/4 |
+| Y position | +$34 | +$38 | (current-prev)/4 |
+
+---
+
+## 4. Surface Tracking
+
+After binary search resolution, evaluates surface height at each probe point using `plane_eval`, then smooths with exponential moving average:
+
+```
+new_height = (old_height + eval_height) / 2
+```
+
+Alpha = 0.5 provides temporal smoothing, preventing height jitter on rough terrain.
+
+**Output fields:**
+- +$5A: probe 1 height
+- +$5C: probe 2 height
+- +$5E: probe 3 height
+- +$32: center height (y_sub)
+
+---
+
+## 5. Directional Collision Probes (`directional_collision_probe`, $7AD6)
+
+**ROM:** $007AD6-$007BAC (214 bytes)
+**Source:** [directional_collision_probe.asm](disasm/modules/68k/game/collision/directional_collision_probe.asm)
+
+Heading-aligned probing for terrain preview:
+
+1. **Forward probe:** Offset from heading angle via ROM table at $0093661E (256 entries, 2 bytes each: signed x,y). Index = `(heading + scale) >> 6`. Evaluates surface height, EMA smooth → +$C6.
+
+2. **Adjacent probe:** Offsets by $7FF entries (~90°) in same table. EMA smooth → +$C8.
+
+3. **Center probe:** Entity's own position as fallback. Same-tile optimization.
+
+---
+
+## 6. Object-to-Object Collision (`object_collision_detection`, $AF18)
+
+**ROM:** $00AF18-$00AFC2 (170 bytes)
+**Source:** [object_collision_detection.asm](disasm/modules/68k/game/collision/object_collision_detection.asm)
+
+Player (A0) vs opponent at $9F00 (A1):
+
+```
+1. ALREADY-ACTIVE CHECK:
+   sum = accel_x + velocity_x (both entities)
+   if nonzero → skip (already processing)
+
+2. DISTANCE GATE:
+   if |lateral_offset_diff| >= $200 → skip
+
+3. PROXIMITY TEST:
+   call zone_check_inner
+   if no collision → skip
+
+4. SOUND TRIGGER: $B8 → $C8A4
+
+5. SPEED COMPARISON:
+   if |speed_diff| <= threshold ($C8CE):
+     call position_separation (gentle push)
+     return
+
+6. WEIGHTED SPEED AVERAGE:
+   faster = speed_sum × 3/4              // clamp to $04DC
+   slower = speed_sum × 3/8              // clamp to $04DC
+   assign based on which entity was faster
+
+7. COLLISION FLAGS:
+   if velocity_gap > $C8D0 threshold:
+     set bit $0800 in both entities' +$02
+```
+
+---
+
+## 7. Proximity System
+
+### 7.1 Zone Classification (4 Levels)
+
+| Zone | Value | Bit 15 | Meaning |
+|------|-------|--------|---------|
+| Far | $0000 | 0 | Outside all thresholds |
+| Approaching | $0003 | 0 | Within outer threshold |
+| Near | $0002 | 0 | Within middle threshold |
+| Inner 1 | $8001 | 1 | Closest range |
+| Inner 2 | $8002 | 1 | Close (critical) |
+
+Callers can test bit 15 with `BMI` for fast critical-proximity detection.
+
+### 7.2 Variants
+
+**`proximity_zone_loop`** ($877A, 104 bytes): Fixed thresholds $140/$2C0/$1000. Iterates 15 entities at $9100 with $100 stride. Writes zone to entity +$C0.
+
+**`proximity_zone_multi`** ($86C8, 178 bytes): Camera override (uses $C0BA/$C0BE if nonzero). Flag-dependent threshold sets:
+- Normal: $140/$1C0/$400/$800
+- Wide: $800/$FA0
+- Alternate: $2C0/$1000
+4 zone levels including $8002.
+
+**`proximity_zone_simple`** ($8672, 86 bytes): Single entity pair, thresholds $200/$1000.
+
+**`proximity_check_simple`** ($39EC, 82 bytes): 3D range test + sprite data copy.
+
+### 7.3 15-Entity Iteration
+
+`proximity_zone_loop` scans all 15 entities in Table 1 ($FF9100, stride $100):
+```
+for i = 0..14:
+  entity = $9100 + i × $100
+  dist = |entity.x - ref.x| + |entity.y - ref.y|    // Manhattan
+  zone = classify(dist)
+  entity.zone = zone
+```
+
+---
+
+## 8. Rotational Offset (`rotational_offset_calc`, $764E)
+
+**ROM:** $00764E-$0076A2 (84 bytes)
+
+Standard 2D rotation matrix for billboard rendering:
+
+```
+lateral    = -(cos × dX + sin × dY) >> 8    → +$72
+longitudinal = (sin × dX - cos × dY) >> 8   → +$E2
+```
+
+Uses `sine_cosine_quadrant_lookup`, heading from +$1E, target from +$20/+$22, position from +$30/+$34.
+
+---
+
+## 9. Angle-Based Visibility (`zone_check_inner`, $AE06)
+
+**ROM:** $00AE06-$00AED6 (210 bytes)
+
+Two symmetric passes using a 2KB lookup table at `($C268)`:
+- **Pass 1:** A1's facing vs A0's position → 4 zone bits in A0+$89
+- **Pass 2:** A0's facing vs A1's position → 4 zone bits in A1+$89
+- Each pass advances $800 bytes (2KB) through the table per zone
+
+Bounding boxes from RAM: $C8E4-$C8EA (pass 1), $C8EC-$C8F2 (pass 2).
+
+---
+
+## 10. Entity Field Map (Collision-Relevant)
+
+| Offset | Size | Name | Written By |
+|--------|------|------|------------|
+| +$30 | word | x_position | Binary search rollback, position_separation |
+| +$32 | word | y_sub | Surface tracking EMA (center) |
+| +$34 | word | y_position | Binary search rollback, position_separation |
+| +$36 | word | prev_x | Snapshot (for binary search) |
+| +$38 | word | prev_y | Snapshot |
+| +$40 | word | heading | Binary search rollback |
+| +$42 | word | prev_heading | Snapshot |
+| +$46 | word | scale | Binary search rollback |
+| +$48 | word | prev_scale | Snapshot |
+| +$55 | byte | combined_flag | OR of all 4 probe results |
+| +$56-$59 | 4 bytes | per_probe_flags | Individual probe collision results |
+| +$5A | word | probe_1_height | EMA smoothed surface height |
+| +$5C | word | probe_2_height | EMA smoothed |
+| +$5E | word | probe_3_height | EMA smoothed |
+| +$62 | word | collision_active | Active collision sequence |
+| +$72 | word | lateral_offset | rotational_offset_calc |
+| +$88 | word | collision_result | object_collision_detection |
+| +$89 | byte | zone_bits | zone_check_inner (4 angle bits) |
+| +$C0 | word | proximity_zone | proximity_zone_loop |
+| +$C6 | word | forward_height | directional_collision_probe EMA |
+| +$C8 | word | adjacent_height | directional_collision_probe EMA |
+| +$CE | long | tile_ptr_center | Center tile data |
+| +$D2 | long | tile_ptr_1 | Probe 1 tile data |
+| +$D6 | long | tile_ptr_2 | Probe 2 tile data |
+| +$DA | long | tile_ptr_3 | Probe 3 tile data |
+| +$DE | long | tile_ptr_4 | Probe 4 tile data |
+| +$E2 | word | long_offset | rotational_offset_calc (longitudinal) |
+
+---
+
+## 11. Cross-Subsystem Interfaces
+
+- **Physics → Collision:** `entity_pos_update` ($6F98) tail-calls `collision_response_surface_tracking` ($7700) via JMP
+- **Collision → Track:** `track_boundary_collision_detection` calls `track_data_index_calc_table_lookup` (5× per binary search iteration) and `track_data_extract_033` (1×)
+- **AI → Collision:** `ai_target_check` calls `proximity_distance_check` → `zone_check_inner`
+- **Collision → AI:** `close_position_flags` sets AI mode $B2 and direction bits
+- **Collision → Sound:** `object_collision_detection` triggers sound $B8

--- a/analysis/ENTITY_OBJECT_ARCHITECTURE.md
+++ b/analysis/ENTITY_OBJECT_ARCHITECTURE.md
@@ -1,0 +1,305 @@
+# Entity/Object Architecture — Virtua Racing Deluxe (32X)
+
+## 1. Overview
+
+The entity system is a **dual-layer architecture**: 68K-side entity tables in Work RAM ($FF9000-$FF9FFF) hold game state, which is projected into a display object array ($FF6218) and then DMA-transferred to SH2 SDRAM for 3D rendering.
+
+**46 modules** across `disasm/modules/68k/object/` (11) and `disasm/modules/68k/game/entity/` (35).
+
+**Key characteristics:**
+- 4 object tables: Player, AI (15 entities), Secondary (8), Special (1)
+- Fixed 256-byte records ($100 stride) — simplifies address arithmetic
+- 20-subroutine per-frame pipeline for the player entity
+- Type dispatch via RAM indirection table at $C05C (runtime-reconfigurable)
+- Display objects ($FF6218, 60B stride) are the final 68K output before SH2 transfer
+- All display data sent to SH2 in a single 2560-byte FIFO burst per frame
+
+---
+
+## 2. 68K Object Tables
+
+Four tables in Work RAM, all using 256-byte ($100) stride:
+
+| Table | Base | Entries | Size | Purpose | Init Function |
+|-------|------|---------|------|---------|---------------|
+| **0 (Player)** | `$FF9000` | 16 | 4KB | Player entity + world state | `object_entry_loader_loop_table_lookup`, `object_entries_reset_init_fixed_table` |
+| **1 (AI)** | `$FF9100` | 15 | 3840B | AI opponent entities | `object_table_init_entry_array` (ROM $00898A7C) |
+| **2 (Secondary)** | `$FF9700` | 8 | 2KB | Trackside objects | `object_table_clear_loop` |
+| **3 (Special)** | `$FF9F00` | 1 | 256B | 2P alternate / camera target | `dual_object_entry_init_primary_alternate` |
+
+**Tables 0 and 3 are paired:** `dual_object_entry_init_primary_alternate` ($00CE02) initializes both from the same ROM data but with different counter phases (Table 0: counters=15, Table 3: counters=0). Table 3 is used for 2-player alternate viewport, trackside proximity checks, and collision detection.
+
+**Table 1 initialization:** `object_table_init_entry_array` ($00CD4C) reads ROM table at $00898A7C indexed by game mode ($C8A0), fills 15 entries with staggered phase counters at +$A4/+$A6 (0-15 modular), sprite sub-index at +$C2, and model data at +$24 from $C710.
+
+**Table 1 speed data:** `entity_table_load` ($00A7E2) copies speed attributes from ROM $00938F2E (indexed by mode) into entity +$0A (max speed) and +$B6 (speed attribute) for all 15 entries.
+
+**Reference counts:** $9000 appears in 47 locations/22 files; $9100 in 14/9; $9700 in 5/4; $9F00 in 16/11.
+
+---
+
+## 3. Entity Record Field Map (256 Bytes)
+
+Each entity occupies $100 bytes. Fields consolidated from all modules:
+
+| Offset | Size | Name | Primary Users |
+|--------|------|------|---------------|
+| +$02 | word | flags | Control bits (6=inactive, 11=collision, 12-13=direction) |
+| +$04 | word | speed | Base speed / velocity index |
+| +$06 | word | display_speed | Visible speed / entity type |
+| +$0A | word | max_speed | Speed cap (from entity_table_load) |
+| +$0E | word | x_tilt | Banking / interpolation target |
+| +$10 | word | z_tilt / drag | Tilt or drag coefficient |
+| +$14 | word | boost_timer | Countdown for speed boost |
+| +$16 | word | calc_speed | Computed effective speed |
+| +$18 | long | data_ptr | ROM data pointer (from init) |
+| +$1C | word | frame_counter | Entity index / frame counter |
+| +$1E | word | heading | Current heading angle |
+| +$20 | word | target_x | Target position X |
+| +$22 | word | target_y | Target position Y |
+| +$24 | word | track_pos_a | Track segment position |
+| +$26 | word | track_pos_b | Secondary track position |
+| +$2C | long | lap_counter | Control / lap data |
+| +$2E | word | counter | Guard counter (decremented) |
+| +$30 | word | **x_position** | World X coordinate |
+| +$32 | word | y_sub | Sub-position / height |
+| +$34 | word | **y_position** | World Y coordinate |
+| +$36 | word | prev_x | Previous frame X (binary search) |
+| +$38 | word | prev_y | Previous frame Y |
+| +$3A | word | lateral_force | Sine-computed lateral |
+| +$3C | word | heading_mirror | Active heading |
+| +$3E | word | longitudinal | Cosine-computed depth |
+| +$40 | word | heading_angle | Canonical heading |
+| +$42 | word | prev_heading | Previous heading (binary search) |
+| +$44 | word | display_offset | Cleared each frame |
+| +$46 | word | display_scale | Cleared each frame |
+| +$48 | word | prev_scale | Previous scale (binary search) |
+| +$4A | word | display_aux | Cleared each frame |
+| +$4C | word | slip_angle | Angle between heading and velocity |
+| +$4E | word | velocity_z | Z velocity component |
+| +$50 | word | velocity_y | Y velocity component |
+| +$52 | word | velocity_x | X velocity component |
+| +$54 | word | steering_flags | Steering mode bits |
+| +$55 | byte | collision_combined | OR of 4 probe results |
+| +$56-$59 | bytes | probe_flags | Individual collision probe results |
+| +$5A | word | probe_1_height | EMA smoothed surface |
+| +$5C | word | probe_2_height | EMA smoothed |
+| +$5E | word | probe_3_height | EMA smoothed |
+| +$62 | word | mode | Multi-use: timer, drift active, collision state |
+| +$64 | word | drift_angle | Angular delta during drift |
+| +$66 | word | drift_target | Target angle for drift |
+| +$68 | word | drift_direction | -1 (left) or +1 (right) |
+| +$6A | word | collision_state | Lateral collision |
+| +$6E | word | roll / height_offset | Roll/height for display |
+| +$72 | word | lateral_offset | Cross-product rotation result |
+| +$74 | word | raw_speed | Gear-scaled speed (0-17000) |
+| +$76 | word | camera_dist | Camera follow distance |
+| +$78 | word | grip | 8.8 fixed-point ($0100 = 1.0) |
+| +$7A | word | gear | Gear index (0-6) |
+| +$7E | word | target_speed | Smoothed speed (rate-limited) |
+| +$80 | word | sound_timer | Sound trigger cooldown |
+| +$82 | word | brake_timer | Brake sound cooldown |
+| +$86 | word | ai_cooldown | Opponent select cooldown |
+| +$88 | word | direction_flags | 4-bit directional push |
+| +$89 | byte | zone_bits | Angle-based visibility (4 bits) |
+| +$8C | word | guard_field | Guard check field |
+| +$8E | word | steering_velocity | 8.8 fixed-point |
+| +$90 | word | drift_rate | Steering × speed derivative |
+| +$92 | word | slide | Slide / drift cooldown |
+| +$94 | word | lateral_velocity | Force-integrated lateral |
+| +$96 | word | position_offset | Display-mapped lateral |
+| +$A4 | word | target_index_1 | Primary target entity |
+| +$A6 | word | target_index_2 | Secondary target |
+| +$A8 | word | speed_state | Multiplier chain selector |
+| +$AA | word | drift_accum | Drift accumulator (0-200) |
+| +$AE | word | entity_type | Type dispatch index |
+| +$B0 | word | spawn_timer | AI spawn countdown (120 frames) |
+| +$B2 | long | stored_position | Copied to +$18 per frame |
+| +$B6 | word | speed_attribute | From entity_table_load |
+| +$BC | word | decel / rotation | Deceleration or rotation |
+| +$C0 | word | render_state | Active flag / render dispatch |
+| +$C1 | byte | sprite_type | Sprite definition index |
+| +$C2 | word | sprite_sub | Sprite sub-index |
+| +$C4 | word | angular_value | Display angular parameter |
+| +$C6 | word | forward_height | Directional probe EMA |
+| +$C8 | word | adjacent_height | Directional probe EMA |
+| +$CC | word | distance_result | Distance calc output |
+| +$CE | long | link_ptr / tile_center | BSP link / center tile data |
+| +$D2 | long | tile_ptr_1 | Probe 1 tile data |
+| +$D6 | long | tile_ptr_2 | Probe 2 tile data |
+| +$DA | long | tile_ptr_3 | Probe 3 tile data |
+| +$DE | long | tile_ptr_4 | Probe 4 tile data |
+| +$E2 | word | longitudinal_offset | Cross-product output |
+| +$E4 | byte | flip_flag | Table select (0 or 1) |
+| +$E5 | byte | entity_flags | bit 0=flip, bit 3=visibility, bits 1-2=AI type |
+
+---
+
+## 4. Entity Lifecycle
+
+### 4.1 Initialization
+
+```
+game_mode_track_config
+  → object_entry_loader_loop_table_lookup (Table 0: 16 entries from ROM)
+  → object_table_init_entry_array (Table 1: 15 AI entities from ROM $00898A7C)
+  → dual_object_entry_init_primary_alternate (Table 0 + Table 3)
+  → entity_table_load (speed attributes from ROM $00938F2E)
+  → object_array_init_rom_tables (15 display objects at $FF6218)
+```
+
+### 4.2 Per-Frame Update
+
+`race_entity_update_loop` dispatches to pipeline variants via a 10-entry jump table indexed by `$C07A`:
+
+| Entry | Handler | Pipeline |
+|-------|---------|----------|
+| 0-3 | `entity_render_pipeline` A-D | Decreasing complexity |
+| 4 | `player_entity_frame_update` | Full 20-subroutine pipeline |
+| 5-9 | 2P mode variants | Split-screen variants |
+
+Override: if bit 7 of $C81C set, forces entry [4] (full player pipeline).
+
+### 4.3 Type Dispatch (`entity_type_dispatch`, $A8E0)
+
+Two-level dispatch for AI behavior:
+
+```
+type_index = entity+$AE                    // entity type
+secondary = RAM_table[$C05C + type_index×2] // RAM indirection
+handler = ROM_table[$A8D4 + secondary×4]   // handler pointer
+JSR handler
+```
+
+ROM handler table has 3 entries, all into `ai_entity_main_update_orch`:
+- Entry 1: $A972 (main AI update)
+- Entry 2: $AB88 (spawn timer state)
+- Entry 3: $ABCE (finish/retirement state)
+
+The RAM table at $C05C allows runtime reconfiguration of entity-to-handler mappings per track/mode.
+
+### 4.4 Visibility
+
+Two visibility systems:
+- **`object_visibility`** ($002EC6): 6 slots at 20B stride from A1 display buffer. Checks $C31C flag + E5 bit 3.
+- **`entity_visibility_check`** ($002C9A): 4 slots at offsets $118/$12C/$140/$154 into A2 buffer. Tests entity active flag (+$C0), writes display parameters.
+
+---
+
+## 5. Per-Frame Pipeline (Player Entity)
+
+`player_entity_frame_update` ($005D08, 192 bytes) runs 20 subroutines:
+
+| # | Function | Purpose |
+|---|----------|---------|
+| 1 | `field_check_guard` | Skip if +$8C = 0 |
+| 2 | `timer_decrement_multi` | Decrement multiple timers |
+| 3 | `suspension_steering_damping` | Steering physics damping |
+| 4 | `object_anim_timer_speed_clear+6` | Animation timer |
+| 5 | `entity_pos_update` | Position integration → collision |
+| 6 | `multi_flag_test` | AND collision probe flags |
+| 7 | `angle_to_sine` | Heading → sine for movement |
+| 8 | `object_link_copy_table_lookup` | Follow link ptr, copy fields |
+| 9 | `rotational_offset_calc` | Cross-product rotation |
+| 10 | `position_threshold_check` | Position comparison + guard |
+| 11 | `race_pos_sorting+50` | Race position sort |
+| 12 | `effect_countdown` | Effect timer decrement |
+| 13 | `set_camera_regs_to_invalid` | Invalidate camera |
+| 14 | `proximity_zone_multi+54` | Multi-zone proximity |
+| 15 | `heading_from_position` | XY → heading |
+| 16 | JSR $0081D8 | Unknown function |
+| 17 | `obj_distance_calc` | Distance computation |
+| 18 | `object_visibility_collector` | Visibility state |
+| 19 | `camera_param_calc` | Camera parameters |
+| 20 | `object_state_disp_0031a6` | State dispatch |
+
+Then 3 render output functions:
+- `object_table_sprite_param_update` — entity → display object conversion
+- `object_proximity_check_jump_table_dispatch` — proximity-based rendering
+- `render_slot_setup+88` — render slot configuration
+
+---
+
+## 6. SH2 Entity Descriptors
+
+The SH2 side has **separate** entity descriptors, distinct from 68K object tables:
+
+| Address | Stride | Entries | Purpose |
+|---------|--------|---------|---------|
+| `$0600C344` | $14 (20B) | 5+ | SH2 entity descriptors (rendering loop 1) |
+| `$0600C3A8` | $14 | — | Entity descriptor group 2 |
+| `$0600C448` | $14 | — | Entity descriptor group 3 |
+| `$0600C800` | $10 (16B) | 32 | Huffman renderer entity data |
+
+These are populated by the SH2 cmd $02 handler (scene orchestrator) from DMA-transferred data, NOT directly from 68K entity tables.
+
+---
+
+## 7. 68K → SH2 Data Flow
+
+### Step 1: Entity Tables → Display Objects
+
+`object_table_sprite_param_update` ($0036DE) iterates 15 entities (Table 1, stride $100) and writes to display object array at $FF6218 (stride $3C = 60 bytes):
+
+**Display Object Layout (60 bytes each):**
+
+| Offset | Source | Description |
+|--------|--------|-------------|
+| +$00 | computed | Visibility flag 1 |
+| +$02 | entity +$30 | Speed / world X |
+| +$04 | entity +$32 + camera | Angle offset |
+| +$06 | entity +$34 | World Y / heading |
+| +$08 | entity +$3A >> 3 | Lateral offset (negated) |
+| +$0A | entity +$3C + +$6E >> 3 | Height with roll |
+| +$0C | entity +$3E >> 3 | Depth offset (negated) |
+| +$0E | — | Secondary table value |
+| +$10 | ROM $008958E4 | Sprite definition pointer |
+| +$14 | computed | Visibility flag 2 |
+| +$1C | entity +$BC >> 3 | Rotation |
+| +$28 | computed | Visibility flag 3 |
+| +$30 | entity +$C4 >> 3 | Angular value |
+
+### Step 2: Display Objects → SH2 via MARS DMA FIFO
+
+`mars_dma_xfer_vdp_fill` ($0028C2) transfers 2560 bytes ($500) from $FF6000 region:
+
+```
+1. Set MARS DREQ length to $500
+2. Write command $0102 (scene orchestrator) to COMM0
+3. Poll COMM1_LO bit 1 for ACK
+4. Stream data via 10 block copy calls:
+   $FF6000-$FF60C7: System/camera state
+   $FF6100-$FF617F: Viewport A (camera + world coords)
+   $FF6218-$FF65FF: Display objects (15 × $3C) + render slots
+   $FF6330-$FF6447: Viewport B (alternate/2P)
+   $FF6448-$FF64AB: Render slot config
+   $FF6800+: VDP register work area
+```
+
+### Step 3: SH2 Processing
+
+Master SH2 cmd $02 handler receives DMA data, writes to SDRAM. Slave SH2 rendering pipeline reads entity descriptors from SDRAM for 3D transform → frustum cull → rasterize.
+
+---
+
+## 8. Display Buffers
+
+| Address | Size | Purpose |
+|---------|------|---------|
+| `$FF6000-$FF60C7` | 200B | System/camera state block |
+| `$FF60C0-$FF60D0` | 16B | Display list (track_graphics_loader init) |
+| `$FF6100-$FF617F` | 128B | Viewport A: camera + world coordinates |
+| `$FF6218-$FF6578` | 864B | Display object array (15 × 60B) |
+| `$FF6330-$FF6447` | 280B | Viewport B: alternate/2P data |
+| `$FF6448-$FF64AB` | 100B | Render slot configuration |
+| `$FF6800-$FF6830` | 48B | SH2 objects (3 × $10) |
+| `$FF6900+` | varies | Display entries (racers) |
+
+---
+
+## 9. Cross-References
+
+- **Entity → Physics:** Per-frame pipeline calls steering, force integration, tilt, drift, pos_update. See [PHYSICS_SYSTEM_ARCHITECTURE.md](PHYSICS_SYSTEM_ARCHITECTURE.md)
+- **Entity → AI:** Type dispatch routes to `ai_entity_main_update_orch`. See [AI_SYSTEM_ARCHITECTURE.md](AI_SYSTEM_ARCHITECTURE.md)
+- **Entity → Collision:** `entity_pos_update` JMPs to `collision_response_surface_tracking`. See [COLLISION_SYSTEM_ARCHITECTURE.md](COLLISION_SYSTEM_ARCHITECTURE.md)
+- **Entity → Rendering:** Display objects at $FF6218 are DMA-transferred to SH2. See [RENDERING_PIPELINE.md](RENDERING_PIPELINE.md)
+- **Entity → Memory:** Object table clearing uses `QuadMemoryFill`. See [MEMORY_MANAGEMENT_ARCHITECTURE.md](MEMORY_MANAGEMENT_ARCHITECTURE.md)

--- a/analysis/MEMORY_MANAGEMENT_ARCHITECTURE.md
+++ b/analysis/MEMORY_MANAGEMENT_ARCHITECTURE.md
@@ -1,0 +1,219 @@
+# Memory Management Architecture — Virtua Racing Deluxe (32X)
+
+## 1. Overview
+
+Virtua Racing Deluxe uses **no dynamic memory allocation**. All buffers are statically mapped to fixed addresses in 68K Work RAM ($FF0000-$FFFFFF, 64KB). There is no heap, no malloc/free, no garbage collection.
+
+The "memory management" subsystem consists of:
+- **High-speed fill/copy primitives** using the JSR cascade ("waterfall") technique
+- **A MOVEM-based block copier** with SH2 busy-guard
+- **A 16-bit PRNG** (multiply-by-41, XOR-fold)
+
+All primitives live in a single ROM region: **$004836-$004996** (352 bytes).
+
+**Source files:** `disasm/modules/68k/memory/` (12 files, 4 are empty stubs)
+
+---
+
+## 2. WRAM Region Map ($FF0000-$FFFFFF)
+
+| Range | Size | Owner | Purpose |
+|-------|------|-------|---------|
+| `$FF0000-$FF001F` | 32B | main-loop | Self-modifying main loop (copied from ROM $000F92) |
+| `$FF6000-$FF60D0` | 208B | display | Screen coordinate / display list buffers |
+| `$FF6100-$FF63FF` | 768B | display | Camera/VDP parameter buffers (P1 at $6100, P2 at $6330) |
+| `$FF6218-$FF6578` | 864B | entity | 15-entry object array (60B stride) |
+| `$FF6800-$FF6830` | 48B | entity | SH2 objects (3 entries, $10 stride) |
+| `$FF6900+` | varies | entity | Display entries (racers) |
+| `$FF6950-$FF6960` | 16B | display | Display flags and state |
+| `$FF9000-$FF90FF` | 256B | entity | Player entity (Object Table 0) |
+| `$FF9100-$FF9FFF` | 3840B | entity | AI entities (Table 1, 15 entries x 256B) |
+| `$FF9700-$FF9EFF` | 2048B | entity | Secondary objects (Table 2, 8 x 256B) |
+| `$FF9F00-$FF9FFF` | 256B | entity | Special entity (Table 3) |
+| `$FFA000-$FFA3FF` | 1024B | camera | Camera position data |
+| `$FFA400-$FFA7FF` | 1024B | palette | Palette destination (block_copy target) |
+| `$FFB400-$FFB7FF` | 1024B | palette | Palette source (block_copy source) |
+| `$FFC000-$FFC09F` | 160B | system | System control (track pointers, speed factors, AI state) |
+| `$FFC268` | 4B | track | Track data pointer |
+| `$FFC710-$FFC73F` | 48B | track | Segment data buffer (5 longwords + 9 words) |
+| `$FFC744` | 4B | track | Segment table pointer |
+| `$FFC800-$FFC8FF` | 256B | state | Game state machine ($C80C frame toggle, $C80E SH2 busy, $C822 sound cmd, $C87A V-INT state, $C87E sub-state, $C8A0 race state, $C8A8 command staging, $C8BC segment index) |
+| `$FFC900-$FFCFFF` | 1792B | state | Extended game state, race data |
+| `$FFEF00` | 4B | math | PRNG seed (32-bit state) |
+| `$FFFB00` | 4B | sh2 | cmd27 async queue indices |
+| `$FFFC00` | 4B | sh2 | General command queue indices |
+| `$FFFEE0-$FFFFFF` | 288B | system | Stack area + controller config |
+
+**Initialization:** `adapter_init` at ROM $000936 clears 32,000 bytes (8000 longwords) starting at $FFC800, wrapping around through $FFFFFF to $FF44FF. Individual state variables ($FFC87A, $FFFB00, $FFFC00, $FFC80C, $FFC80E, $FFC82A) are explicitly cleared before the bulk fill.
+
+---
+
+## 3. Memory Primitives
+
+### 3.1 JSR Cascade ("Waterfall") Technique
+
+The game's signature optimization pattern. Instead of DBRA loops (10 cycles overhead per iteration), it uses nested `JSR label(PC)` calls to multiply execution of an unrolled body:
+
+```
+; Pseudocode for a 2-level cascade:
+cascade_2:
+    jsr body(pc)      ; pushes return addr, jumps to body
+body:                   ; 16 x MOVE.L D1,(A1)+
+    move.l d1,(a1)+
+    ...                 ; 15 more
+    rts                 ; returns to instruction after the JSR
+                        ; → falls through to body again!
+                        ; body executes a 2nd time, then RTS exits cascade_2
+```
+
+Each nesting level doubles execution. Callers enter at different offsets to select the fill/copy size, making one function body serve dozens of size requirements.
+
+### 3.2 `quad_memory_fill` — ROM $004836 (82 bytes)
+
+4-level JSR cascade over a 16-longword unrolled fill body.
+
+**Registers:** D1 = fill value (longword), A1 = destination (advances)
+
+**Entry points (by offset):**
+
+| Entry | ROM Address | Cascade Depth | Fill Size |
+|-------|------------|--------------|-----------|
+| `quad_memory_fill` | $004836 | 4 levels | 112 bytes |
+| `+4` | $00483A | 3 levels | 96 bytes |
+| `+8` | $00483E | 2 levels | 80 bytes |
+| `+12` | $004842 | 1 level | 64 bytes |
+| `+16` (body) | $004846 | 0 (direct) | variable |
+
+**Callers:** `animated_seq_player.asm:47` (+16), `race_scene_init_004a32.asm:20` (+8), `z80_commands.asm:154` (+8)
+
+**Source:** [quad_memory_fill.asm](disasm/modules/68k/memory/quad_memory_fill.asm)
+
+### 3.3 `fast_fill_128_fixed` — ROM $004888 (66 bytes)
+
+32 consecutive `MOVE.L D1,(A6)` to a **fixed** (non-incrementing) address. Designed for VDP data port / hardware FIFO writes where the destination register is memory-mapped.
+
+**Registers:** D1 = fill value, A6 = destination (fixed, does NOT advance)
+
+**Entry points:** Full (128B), +32 (64B), +48 (32B via `UnrolledFill32` label)
+
+**Callers:** `init_sequence.asm:1076,1080` (2x), `vdp_dma_xfer_vram_clear.asm:52,56` (2x), `z80_commands.asm:150`
+
+**Source:** [fast_fill_128_fixed.asm](disasm/modules/68k/memory/fast_fill_128_fixed.asm)
+
+### 3.4 `triple_memory_copy` — ROM $0048CA (98 bytes)
+
+3-level JSR cascade with an internal skip-ahead JSR. Copies `(A1)+` to `(A2)+`.
+
+The internal structure uses a skip JSR to jump over 16 MOVE.L instructions to reach a second block of 24 MOVE.Ls. On return, the skipped 16 execute, then control falls through to the 24-block again. This creates a 40-longword inner unit that the cascade multiplies.
+
+**Registers:** A1 = source (advances), A2 = destination (advances)
+
+**Entry points:** `+0` (full), `+8` (4x body), `+32` (~160B), `+80` (partial), `+88` (72B via `UnrolledCopy72`)
+
+**Callers:** 11 call sites across 7 files including `v_int_cram_xfer_gate.asm:19`, `race_scene_data_loader.asm:23,26,31,36` (4x), `tile_block_dma_setup.asm:29`
+
+**Source:** [triple_memory_copy.asm](disasm/modules/68k/memory/triple_memory_copy.asm)
+
+### 3.5 `FastCopy20/16/12/8/4` — ROM $004920 (12 bytes)
+
+The **most-used copy function** in the game (28 call sites across 9+ files). Five staggered entry points over 5 consecutive `MOVE.L (A1)+,(A2)+` instructions.
+
+**Registers:** A1 = source, A2 = destination (both advance)
+
+| Entry | Address | Copies |
+|-------|---------|--------|
+| `FastCopy20` | $004920 | 5 longs = 20 bytes |
+| `FastCopy16` | $004922 | 4 longs = 16 bytes |
+| `FastCopy12` | $004924 | 3 longs = 12 bytes |
+| `FastCopy8` | $004926 | 2 longs = 8 bytes |
+| `FastCopy4` | $004928 | 1 long = 4 bytes |
+
+**Source:** [fast_copy.asm](disasm/modules/68k/memory/fast_copy.asm)
+
+### 3.6 `fast_copy_128_fixed` — ROM $00492C (66 bytes)
+
+32 consecutive `MOVE.L (A1)+,(A6)` to a fixed address. The copy equivalent of `fast_fill_128_fixed` — reads from advancing source, writes to fixed destination (VDP data port).
+
+**Registers:** A1 = source (advances by 128), A6 = destination (fixed)
+
+**Entry points:** `FastCopyA6_64` ($00492C, 64B), `FastCopyA6_60` ($00494E, 60B)
+
+**Source:** [fast_copy_128_fixed.asm](disasm/modules/68k/memory/fast_copy_128_fixed.asm)
+
+### 3.7 `block_copy_with_check` — ROM $0046EE (48 bytes)
+
+MOVEM-based 1024-byte block copy with SH2 busy-guard. Copies palette data from $FFB400 (source) to $FFA400 (destination).
+
+**Algorithm:**
+1. Set `$FFC048 = 1` (camera state flag)
+2. Test bit 7 of `$FFC80E` — if SH2 busy, skip copy entirely
+3. Loop 32x: `MOVEM.L (A1)+,D0-D6/A3` (read 32B), `MOVEM.L D0-D6/A3,-(A2)` (write 32B, predecrement)
+4. Queue sound `$F3` to `$FFC822`
+5. Advance `$FFC8BE` by 4
+
+**Note:** Predecrement on destination means the copy writes backward. A2 starts at $FFA400 and decrements, so actual destination is $FFA000-$FFA3FF.
+
+**Registers:** D0-D6, A1, A2, A3, D7 (all clobbered)
+
+**Source:** [block_copy_with_check.asm](disasm/modules/68k/memory/block_copy_with_check.asm)
+
+---
+
+## 4. PRNG
+
+**ROM address:** $00496E-$004996 (42 bytes)
+**Seed location:** `$FFFFEF00` (32-bit state)
+**Default seed:** `$2A6D365A`
+
+**Algorithm (multiply-by-41, XOR-fold):**
+```
+1. D0 = seed from $FFEF00
+2. If zero → substitute $2A6D365A
+3. D1 = D0           ; copy
+4. D1 = D1 << 2      ; × 4
+5. D1 = D1 + D0      ; × 5
+6. D1 = D1 << 3      ; × 40
+7. D1 = D1 + D0      ; × 41
+8. D0.W = D1.low + D1.high  ; XOR-fold to 16 bits (addition, not XOR)
+9. D1.W = D0.W       ; merge into state
+10. SWAP D1           ; rotate high/low
+11. Store D1 → $FFEF00
+12. Return D0.W = 16-bit random value
+```
+
+**Callers (6 per frame):** 3 sound randomizers (`randomized_sound_param_*.asm`) + 3 timer randomizers (`randomized_timer_decrement_*.asm`)
+
+**Source:** `disasm/modules/68k/math/random_number_gen.asm`, `disasm/modules/68k/util/random.asm`
+
+---
+
+## 5. Usage Patterns
+
+### Initialization (boot)
+`adapter_init` clears 32,000 bytes starting at $FFC800 (wrapping through $FFFFFF to $FF44FF) using a DBRA loop of 8000 longword writes. Individual state variables are explicitly cleared before the bulk fill.
+
+### Per-Frame Operations
+- **Palette copy:** `block_copy_with_check` copies 1KB $FFB400→$FFA400 when SH2 is not busy
+- **VDP fills:** `fast_fill_128_fixed` writes repeated longwords to VDP data port (A6 fixed)
+- **VDP data transfers:** `fast_copy_128_fixed` streams source data to VDP data port
+- **Display list builds:** `FastCopy16` is the workhorse — used for 16-byte sprite parameter copies across the display system
+- **Scene loading:** `triple_memory_copy` handles large ROM→WRAM copies during scene transitions (palette, tile data, track graphics)
+
+### Performance Characteristics
+| Technique | Throughput | Overhead |
+|-----------|-----------|----------|
+| DBRA loop (`MOVE.L (A1)+,(A2)+`) | ~12 cycles/long | 10 cycles/iteration (DBRA) |
+| Unrolled `MOVE.L` chain | ~12 cycles/long | 0 (no branch) |
+| JSR cascade (4-level) | ~12 cycles/long | 4 × JSR+RTS = ~80 cycles total |
+| MOVEM (8 registers) | ~8 cycles/long | ~44 cycles setup per 32B block |
+
+The JSR cascade amortizes its ~80 cycle overhead over hundreds of longword moves. For large fills (>64 bytes), it matches raw unrolled speed. For small copies (4-20 bytes), the direct `FastCopy` entry points have zero overhead.
+
+---
+
+## 6. Design Philosophy
+
+1. **Speed over flexibility** — No general-purpose allocator. Every buffer is at a known address, allowing direct `LEA` access without pointer chasing.
+2. **Code size over generality** — One unrolled body with multiple entry points serves all copy sizes. The JSR cascade trades 80 bytes of code for thousands of cycles saved per frame.
+3. **Hardware-aware variants** — Fixed-address versions (`fast_fill_128_fixed`, `fast_copy_128_fixed`) exist specifically for VDP FIFO writes where the destination must not increment.
+4. **Guard patterns** — `block_copy_with_check` tests the SH2 busy flag before large copies, preventing corruption during concurrent DMA operations.

--- a/analysis/PHYSICS_SYSTEM_ARCHITECTURE.md
+++ b/analysis/PHYSICS_SYSTEM_ARCHITECTURE.md
@@ -1,0 +1,315 @@
+# Physics System Architecture — Virtua Racing Deluxe (32X)
+
+## 1. Overview
+
+The physics system is a **per-frame vehicle simulation** running on the 68K. It processes speed, steering, force integration, grip, drift, tilt, and position integration in a fixed 17-step pipeline called from `entity_render_pipeline`.
+
+**51 modules** in `disasm/modules/68k/game/physics/`, totaling ~4.5KB of code.
+
+**Key characteristics:**
+- 8.8 fixed-point grip ($0100 = 1.0)
+- 7-gear transmission with multiplicative ratio table
+- 384-entry speed lookup table at $19DA4
+- Per-frame speed delta clamped to +/-1024
+- Falls through to collision system (no RTS boundary at `entity_pos_update` → `collision_response_surface_tracking`)
+
+---
+
+## 2. Execution Pipeline (Per-Frame Order)
+
+From `entity_render_pipeline` Variant A (full player pipeline at $005AB6):
+
+```
+ 1. camera_state_selector+12         — select camera mode
+ 2. clear display offsets (+$44, +$46, +$4A = 0)
+ 3. tire_squeal_check                — sound effect guard
+ 4. speed_degrade_calc ($00859A)     — speed → drag at +$BC
+ 5. effect_timer_mgmt                — manage effect timers
+ 6. object_timer_expire ($008170)    — +$62 countdown
+ 7. field_check_guard                — guard checks
+ 8. timer_decrement_multi            — multiple timer decrements
+ 9. steering_input_processing ($0094FA) — controller → +$8E steering
+10. entity_force_integration ($009312)  — drag/friction → +$74, +$78, +$0C, +$06
+11. entity_speed_clamp ($009B12)     — +$06 → +$04 via ×$48/256
+12. entity_speed_accel_and_braking ($009182) — gear shifts on +$74/+$7A
+13. tilt_adjust ($00961E)            — banking on +$0E, +$10
+14. drift_physics ($009688)          — drift → +$3C, +$76
+15. suspension_steering_damping      — damping
+16. object_anim_timer_speed_clear+6  — animation reset
+17. entity_pos_update ($006F98)      — heading + speed → +$30, +$34
+    └── [JMP] collision_response_surface_tracking ($007700)
+```
+
+**Pipeline variants:**
+- **A** (full player): All 17 steps
+- **B** (non-player): Drops steering, drift, pos_update
+- **C** (countdown): Adds pre-race countdown timer logic
+- **D** (spectator/replay): Drops steering and drift, keeps pos_update
+
+---
+
+## 3. Speed System
+
+### 3.1 Speed Field Map
+
+The "speed" flows through multiple representations:
+
+| Field | Offset | Range | Description |
+|-------|--------|-------|-------------|
+| `raw_speed` | +$74 | 0-17000 | Gear-scaled internal speed |
+| `target_speed` | +$7E | 0-17000 | Smoothed +$74 (rate-limited +/-1024/frame) |
+| `display_speed` | +$06 | — | Accumulated via slope delta from force integration |
+| `speed` | +$04 | — | `display_speed × $48 / 256` (entity_speed_clamp output) |
+| `calc_speed` | +$16 | — | Effective speed from table + multipliers (friction input) |
+
+### 3.2 Speed Lookup Table
+
+384-entry table at ROM $00899DA4 (via RAM pointer `$C27C`). Indexed by `+$04` (velocity_index). Returns base speed used by the multiplier chain.
+
+### 3.3 Multiplier Chain (`speed_calc_multiplier_chain`, $009458)
+
+```
+base_speed = speed_table[entity.velocity_index]
+calc_speed = (base_speed × track_speed_factor) >> 8
+
+if has_boost_flag:   calc_speed = calc_speed × (16 + boost_modifier) >> 4
+if speed_state > 4:  calc_speed = calc_speed × 11 / 16     // ~0.69× high-speed reducer
+elif speed_state≠0:  calc_speed ×= 1.5                     // braking boost
+if wind_active:      calc_speed ×= 1.75                    // +3/4
+if boost_timer > 0:  calc_speed += $738; timer--
+```
+
+### 3.4 Force Integration (`entity_force_integration_and_speed_calc`, $009300)
+
+The core physics function. Computes net force from drag, friction, and air resistance, applies grip scaling:
+
+```
+raw_speed = clamp(+$74, 0, 17000)
+table_idx = raw_speed >> 7
+drag_coeff = drag_table[surface][table_idx] × gear_table[gear] >> 5
+net_force = (drag_coeff × entity.force) >> 7
+
+friction = calc_speed << 4
+net_force -= friction
+air_drag = (entity.drag × $71C0) >> 7
+net_force -= air_drag
+if net_force < 0: net_force ×= 2        // double deceleration penalty
+
+// Grip computation
+entity.grip = $0100                      // reset to 1.0
+if net_force exceeds max_threshold:
+  excess = (excess << 8) / max_threshold
+  entity.grip -= excess                  // reduce grip (min 0.5)
+  trigger tire squeal $B4
+
+final_force = (net_force >> 1) × entity.grip >> 7
+entity.slope = final_force >> 2 / 400
+entity.display_speed += entity.slope
+entity.raw_speed = display_speed × gear_mult × 596 / 4096
+```
+
+**Drag tables:** Road at $0093910E, off-road at $00938FCE. Indexed by `raw_speed >> 7`.
+
+### 3.5 Gear System (`entity_speed_acceleration_and_braking`, $009182)
+
+7 gears (0-6). Transitions use multiplicative ratios from table at $0088A1F0:
+- **Upshift:** `raw_speed = (raw_speed × ratio[gear]) >> 8; gear++`
+- **Downshift:** `raw_speed = (raw_speed << 8) / ratio[gear]; gear--`
+- **Natural shifts** at per-gear thresholds from $0088A1E2 (upshift) and $00939EDE (downshift)
+- Per-frame delta clamped to +/-$400 (1024)
+
+---
+
+## 4. Steering and Heading
+
+### 4.1 Controller Input (`steering_input_processing_and_velocity_update`, $0094F4)
+
+```
+Read L/R from controller bits → D0 (horizontal direction)
+
+if direction_changed:
+  steering_vel = accel_table[direction]   // inline: [-24, +24, 0]
+  entity.steer = steering_vel << 8
+elif no_input:
+  centering damping (subtract damp_table[sign(vel)])
+elif same_direction:
+  accelerate (halve if countersteering same-sign as drift)
+  steering_vel += accel
+
+clamp(steering_vel, -127, +127)
+if |steering_vel| < 24: steering_vel = 0    // deadzone
+
+// Smoothing filter (EMA)
+new_steer = (steering_vel << 8 + old_steer) / 2
+drift_accum = clamp(drift_accum + |delta|>>8, 0, 200)
+
+if |new_steer| < 24: new_steer = 0          // final deadzone
+entity.steering_velocity = new_steer
+```
+
+### 4.2 Position Integration (`entity_pos_update`, $006F98)
+
+```
+heading = entity.heading_mirror + entity.heading_offset
+entity.heading_angle = heading
+heading = -heading
+
+dx = sin(heading) × speed >> 12
+x_position += dx
+dy = cos(heading) × speed >> 12
+y_position += dy
+
+JMP collision_response_surface_tracking    // no RTS — falls through!
+```
+
+Sine/cosine from main trig table at $00930000 via `sine_cosine_quadrant_lookup` ($008F4E).
+
+### 4.3 AI Entity Path (`physics_integration`, $00A666)
+
+AI entities bypass controller input and use target-seeking:
+
+```
+distance = |target_x - pos_x| + |target_y - pos_y|    // Manhattan
+frames_to_target = (distance << 4) / (speed + 1)
+steering_factor = max(1, frames_to_target / 2)
+
+target_heading = ai_steering_calc(pos, target)          // atan2 approx
+heading_delta = (target_heading - heading) / steering_factor
+heading += heading_delta
+
+x_pos += (sin(heading) × speed) >> 12
+y_pos += (cos(heading) × speed) >> 12
+```
+
+**Note:** `collision_avoidance_speed_calc` ($00A470) falls through directly to `physics_integration` with no RTS boundary. See [AI_SYSTEM_ARCHITECTURE.md](AI_SYSTEM_ARCHITECTURE.md) §5.
+
+---
+
+## 5. Tilt and Banking (`tilt_adjust`, $00961E)
+
+```
+if collision OR lateral_flag: return
+
+tilt_rate = 48
+// X-tilt: track tilt direction
+if track_tilt < entity.direction: tilt_rate = -48
+entity.x_tilt = clamp(entity.x_tilt + tilt_rate, -51, 255)
+
+// Z-tilt: Z direction flag
+if Z_direction not set: tilt_rate = -48
+entity.z_tilt = clamp(entity.z_tilt + tilt_rate, 0, 255)
+```
+
+---
+
+## 6. Drift Model
+
+### 6.1 Lateral Drift (`lateral_drift_velocity_processing_00987e`, $00987E)
+
+Two variants: A (standard) and B ($0099AA, adds AI boost + viewport scaling).
+
+```
+grip -= (|steering_input| × drag) >> 8     // steering reduces grip
+clamp(grip, 127, ...)
+
+if |slip_angle| <= 55: goto natural_damping
+
+// Force integration
+if low_velocity:
+  force = slip × (512 - grip) >> 8
+  lateral_vel += force
+else:
+  force = slip × 3/8
+  lateral_vel += force
+  heading -= (lateral_vel × correction_coeff) >> 8
+  if |lateral_vel| >= spin_limit:
+    trigger spin-out (sound $B2, flag $1000/$2000)
+
+natural_damping:
+  drag_force = clamped_vel × lateral_drag_coeff >> 8
+  lateral_vel -= drag_force
+  if zero_crossing: lateral_vel = 0
+  if |vel| < 16 AND converging: lateral_vel = 0       // settled
+```
+
+### 6.2 Drift Accumulator (+$AA)
+
+Tracks cumulative steering change. Range 0-200, decays by 8/frame. Used to determine when countersteer damping should activate (halves acceleration when countersteering matches drift direction).
+
+---
+
+## 7. Lookup Tables
+
+| Table | ROM Address | Entries | Purpose |
+|-------|------------|---------|---------|
+| Drag (road) | $0093910E | ~134 | Speed-indexed drag coefficients |
+| Drag (off-road) | $00938FCE | ~134 | Off-road drag coefficients |
+| Gear ratios | $0088A1F0 | 7 | Per-gear multiplicative ratios |
+| Natural upshift | $0088A1E2 | 7 | Per-gear speed thresholds |
+| Natural downshift | $00939EDE | 7 | Per-gear decel thresholds |
+| Speed table | $00899DA4 (via $C27C) | 384 | velocity_index → base speed |
+| Speed calc alt | $0093925E | — | Alternative speed lookup |
+| Track physics | $00898818 | per-track | Gear table ptr + 14 physics params |
+| Sine/cosine (full) | $00930000 | 256 | Quadrant-based trig |
+| Turn rate sine | $0093AC2C | 512 | Heading difference sine |
+| Turn rate cosine | $0093A82C | 512 | Lateral force cosine |
+| Physics lookup | $00A218 (inline) | 96 | 6×16 word table |
+| Sine/cosine (mini) | $00A2D8 (inline) | 56 | 64-entry fixed-point |
+| Angle-to-offset | $0093661E | 256 | Directional probe offsets |
+| Steering accel | $0094F4 (inline) | 3 | [-24, +24, 0] |
+
+---
+
+## 8. Entity Field Map (Physics-Relevant)
+
+| Offset | Size | Name | Written By |
+|--------|------|------|------------|
+| +$02 | word | flags | drift (spin-out bits $1000/$2000) |
+| +$04 | word | speed | entity_speed_clamp |
+| +$06 | word | display_speed | force_integration |
+| +$0C | word | slope | force_integration |
+| +$0E | word | x_tilt | tilt_adjust |
+| +$10 | word | z_tilt / drag | tilt_adjust, drift |
+| +$14 | word | boost_timer | multiplier_chain (decrements) |
+| +$16 | word | calc_speed | multiplier_chain |
+| +$30 | word | x_position | entity_pos_update |
+| +$34 | word | y_position | entity_pos_update |
+| +$3C | word | heading_mirror | drift_physics |
+| +$40 | word | heading_angle | entity_pos_update |
+| +$4C | word | slip_angle | drift (input) |
+| +$74 | word | raw_speed | force_integration, speed_accel |
+| +$76 | word | camera_dist | drift_physics |
+| +$78 | word | grip | force_integration (reset), drift (reduce) |
+| +$7A | word | gear | speed_accel (0-6) |
+| +$7E | word | target_speed | speed_accel (rate-limited) |
+| +$8E | word | steering_velocity | steering_input (8.8 fixed-point) |
+| +$90 | word | drift_rate | drift_physics |
+| +$92 | word | slide | drift (multi-use) |
+| +$94 | word | lateral_velocity | drift (force-integrated) |
+| +$96 | word | lateral_display | drift (display-mapped) |
+| +$A8 | word | speed_state | multiplier_chain selector |
+| +$AA | word | drift_accum | steering (0-200, decays 8/frame) |
+| +$BC | word | drag_output | speed_degrade_calc |
+
+---
+
+## 9. Fixed-Point Conventions
+
+| Shift | Usage | Example |
+|-------|-------|---------|
+| >>5 | Gear normalization | drag_coeff × gear_table >> 5 |
+| >>7 | Drag/force scaling | net_force = (drag × force) >> 7 |
+| >>8 | Velocity/grip (8.8) | grip $0100 = 1.0, steering ±127 in 8.8 |
+| >>12 | Position integration | dx = sin × speed >> 12 |
+| <<4 | Friction scaling | friction = calc_speed << 4 |
+| <<8 | Gear ratio multiply | raw_speed × ratio >> 8 (upshift) |
+
+---
+
+## 10. Cross-Subsystem Interfaces
+
+- **Physics → Collision:** `entity_pos_update` tail-calls `collision_response_surface_tracking` via JMP (no RTS boundary)
+- **AI → Physics:** `collision_avoidance_speed_calc` falls through to `physics_integration` at $A666 (no RTS)
+- **Shared utility:** `ai_steering_calc` ($A7A0) used by AI, physics, and camera subsystems
+- **Shared utility:** `sine_cosine_quadrant_lookup` ($8F4E) used by all position/heading calculations
+- **Sound triggers:** Physics writes sound bytes ($B1 skid, $B2 spin-out, $B4 tire squeal) to `$CA94` with 10-15 frame cooldowns at +$80/+$82/+$84

--- a/analysis/SOUND_DRIVER_ARCHITECTURE.md
+++ b/analysis/SOUND_DRIVER_ARCHITECTURE.md
@@ -1,0 +1,413 @@
+# Sound Driver Architecture — Virtua Racing Deluxe (32X)
+
+## 1. Overview
+
+The sound system is a **68K-resident, per-frame tick-based sequencer** controlling three sound chips. Contrary to many Genesis/32X games, the 68K handles all FM and PSG synthesis directly — the Z80 only runs a tiny 653-byte DAC sample playback program.
+
+**Key facts:**
+- **ROM footprint:** $030000-$034200 (~17KB code + data)
+- **RAM state:** $FF8500-$FF8890 (912 bytes, base in A6)
+- **18 channels:** 1 DAC + 6 FM + 3 PSG + 6 SFX overlay + 2 special
+- **Channel struct size:** $30 bytes (48 bytes) per channel
+- **Sound chips:** YM2612 (FM), SN76489 (PSG), Z80-hosted DAC
+- **95 source modules** across `disasm/modules/68k/sound/` (28) and `disasm/modules/68k/game/sound/` (67)
+
+---
+
+## 2. Hardware Interfaces
+
+### YM2612 (FM Synthesis) — 6 channels
+
+| Port | Address | Function |
+|------|---------|----------|
+| Port 0 addr | `$A04000` | Register address (channels 1-3) |
+| Port 0 data | `$A04001` | Register data |
+| Port 1 addr | `$A04002` | Register address (channels 4-6) |
+| Port 1 data | `$A04003` | Register data |
+
+All writes require: (1) Z80 bus ownership (`$A11100 = $0100`), (2) busy-wait on bit 7 of `$A04000`.
+
+**Key FM registers:**
+
+| Register | Purpose |
+|----------|---------|
+| `$28` | Key on/off (operator mask + channel) |
+| `$27` | Timer / special mode control |
+| `$2B` | DAC enable ($80 = on) |
+| `$A0`/$A4` | Frequency LSB/MSB per channel |
+| `$B0` | Feedback/algorithm per channel |
+| `$B4` | L/R panning + LFO per channel |
+
+**Write wrapper hierarchy:**
+- `fm_write_wrapper` ($030CBA) — bus request + write + release
+- `fm_write_cond` ($030CCC) — adds channel offset, checks key-off flag
+- `fm_write_port_0_1` ($030CF4) — channel-offset write to port 1
+- `fm_cond_write_with_bus` ($030CA2) — key-off check + bus acquire + write + release
+
+### SN76489 (PSG) — 3 tone + 1 noise channel
+
+Single write port at `$C00011`. Latch byte format: `{1, channel[1:0], type, data[3:0]}`.
+
+Silence all: write `$9F`, `$BF`, `$DF`, `$FF` (max attenuation per channel).
+
+128-entry frequency lookup table at ROM $030FE0 for note-to-frequency conversion.
+
+### Z80 Communication
+
+The Z80 runs independently. Three mailbox bytes in Z80 RAM:
+
+| Address | Purpose | Direction |
+|---------|---------|-----------|
+| `$A00FFD` | DAC volume (4-bit) | 68K → Z80 |
+| `$$A00FFE` | DAC sample select / command | 68K → Z80 |
+| `$A00FFF` bit 7 | Z80 busy flag | Z80 → 68K |
+
+**Bus protocol:** Request `$A11100=$0100`, poll bit 0 of `$A11100` until granted, check `$A00FFF` bit 7 (retry with NOP delay if busy), perform work, release `$A11100=$0000`.
+
+---
+
+## 3. Game-Level Sound Commands
+
+Game code never calls the driver directly. It writes command bytes to RAM mailbox slots; frame dispatchers relay them.
+
+### Three-Priority Mailbox System
+
+| Priority | Mailbox | Purpose | De-dup |
+|----------|---------|---------|--------|
+| 1 (high) | `$C822` | Music commands (mode changes, race start) | Clears both $C822 and $C8A4 |
+| 2 | `$C8A5` | SFX (collision, tire squeal, race events) | Skips if same as `$C8A7` (last sent) |
+| 3 (low) | `$C8A4` | BGM / ambient (background effects) | Tracked in `$C8A6` |
+
+**Dispatcher:** `sound_command_dispatch_sound_driver_call` at ROM $002080 (86 bytes)
+- Source: [sound_command_dispatch_sound_driver_call.asm](disasm/modules/68k/game/race/sound_command_dispatch_sound_driver_call.asm)
+- Reads mailboxes in priority order, copies to driver state `$8509`/`$850A`, calls `JSR $008B0000`
+
+**Frame integration:** `sound_update_disp` at ROM $0020D6 (280 bytes) provides 7 entry points for different game states. All call `JSR $008B0000` then chain to engine sound frequency calculation.
+- Source: [sound_update_disp.asm](disasm/modules/68k/game/state/sound_update_disp.asm)
+
+**Engine sound:** After the driver tick, `audio_frequency_update` ($00220C) computes engine pitch via weighted shift average + base frequency `$1A5E`, clamped to `[$1A5E, $1E00]`, stored at `$8760`/`$8790`.
+
+---
+
+## 4. Sound Driver Core ($030000)
+
+CPU address `$008B0000` (file offset `$030000`). Two entry points:
+
+### Entry 1 — Main Tick ($030008)
+
+Called once per frame. The complete tick loop:
+
+```
+1. LEA $FF8500,A6              // load driver state base
+2. CLR.B A6+$0E                // clear tick phase flag
+3. TST.B A6+$07                // mute-all flag?
+4. If set → skip to $030482    // (silence, no processing)
+5. JSR fm_fade_in_out_proc     // ($030D4E) fade processing
+6. JSR fm_envelope_tick_update // ($030AF8) advance envelopes
+7. JSR fm_full_silence         // ($030A72) handle silence state
+8. Check A6+$0A → JSR fm_sound_priority_check ($030536)
+9. JSR fm_sound_command_disp   // ($03056A) dispatch new command
+10. DAC channel tick            // (A6+$40) → Z80 $A00FFE
+11. FM channel loop ×6          // (A6+$70, stride $30)
+    → sequence read → frequency → YM2612
+12. PSG channel loop ×3         // (A6+$190, stride $30)
+    → sequence read → frequency → SN76489
+13. SFX channel loops           // (A6+$220, 6 FM + PSG overlays)
+14. Special channel loop ×2     // (A6+$340, A6+$370)
+15. RTS
+```
+
+### Entry 2 — Z80 Upload + Reset ($030BF6)
+
+Uploads Z80 program (653 bytes from ROM $031688) to Z80 RAM `$A00000`, DAC samples (4096 bytes from ROM $031915) to `$A01000`, resets Z80 via toggle, falls through to full silence.
+
+---
+
+## 5. Driver State ($FF8500)
+
+### Global Header ($00-$3F, 64 bytes)
+
+| Offset | Size | Name | Description |
+|--------|------|------|-------------|
+| `+$00` | byte | priority | Current music priority level |
+| `+$01` | byte | speed | Playback speed |
+| `+$02` | byte | tempo | Tempo multiplier |
+| `+$04` | byte | frame_counter | Frames until envelope tick (init: 5) |
+| `+$06` | byte | tick_rate | Reset to 1 each tick |
+| `+$07` | byte | mute_all | Nonzero = skip entire driver tick |
+| `+$08` | byte | cmd_sentinel | Cleared each tick, set to $80 after |
+| `+$09` | byte | active_cmd | Active command ($80 = none) |
+| `+$0A` | byte | new_cmd | Pending command from game |
+| `+$0E` | byte | tick_phase | 0→$80 (music)→$40 (SFX) during tick |
+| `+$0F` | byte | panning_mode | Nonzero = alternate panning table |
+| `+$30` | long | seq_ptr | Master sequence data pointer |
+| `+$34` | long | sfx_seq_ptr | SFX sequence data pointer |
+| `+$38` | byte | fade_state | 0=off, 1=active, 2=complete |
+| `+$39` | byte | dac_fade_rate | Per-frame DAC fade step |
+| `+$3A` | byte | fm_fade_rate | Per-frame FM fade step |
+| `+$3B` | byte | psg_fade_rate | Per-frame PSG fade step |
+
+### Channel Map (18 channels, $30 bytes each)
+
+| Offset | Count | Type | Hardware Target |
+|--------|-------|------|----------------|
+| `+$0040` | 1 | DAC | Z80 $A00FFD/$A00FFE |
+| `+$0070` | 6 | FM | YM2612 channels 1-6 |
+| `+$0190` | 3 | PSG | SN76489 tone channels 0-2 |
+| `+$0220` | 6 | SFX-FM | YM2612 (overlays music FM channels) |
+| `+$0340` | 1 | Special A | DAC overlay |
+| `+$0370` | 1 | Special B | Noise overlay |
+
+Total: 18 × $30 = $360 bytes. Global + channels = $3A0 (928 bytes).
+
+### Per-Channel Structure ($30 = 48 bytes)
+
+| Offset | Size | Name | Description |
+|--------|------|------|-------------|
+| `+$00` | byte | flags | bit7=active, bit4=sustain, bit2=key-off, bit1=mute |
+| `+$01` | byte | reg_num | FM register / PSG channel ID |
+| `+$02` | byte | tempo | Per-channel tempo divider |
+| `+$03` | byte | multiplier | Pitch scaling factor |
+| `+$04` | long | seq_ptr | Current sequence data pointer |
+| `+$08` | word | init_freq | Initial/base frequency |
+| `+$09` | byte | envelope | Envelope position / volume |
+| `+$0A` | byte | instrument | Instrument index (bit 7 = special) |
+| `+$0B` | byte | env_num | Envelope table index |
+| `+$0C` | byte | env_counter | Envelope position counter |
+| `+$0D` | byte | stride | Struct stride ($30, for iteration) |
+| `+$0E` | byte | duration | Duration timer (ticks remaining) |
+| `+$0F` | byte | dur_reload | Duration reload value |
+| `+$10` | word | note_freq | Current note frequency |
+| `+$18-$1B` | 4B | vibrato | Vibrato parameters |
+| `+$1C` | word | vib_accum | Vibrato accumulator |
+| `+$1E` | word | base_freq | Base frequency for reader |
+| `+$20` | long | sub_seq | Sub-sequence pointer (call/return) |
+| `+$25` | byte | psg_noise | PSG noise register value |
+| `+$26` | byte | seq_pos | Sequence position counter |
+| `+$27` | byte | panning | FM panning ($C0 = center stereo) |
+
+---
+
+## 6. FM Synthesis Engine
+
+### Instrument Loading
+
+**Music instruments ($81-$9F):** `fm_instrument_setup` at $03061C
+- Source: [fm_instrument_setup.asm](disasm/modules/68k/game/sound/fm_instrument_setup.asm)
+- Reads 6-byte header from table at $032AB8: `{seq_offset(word), fm_count(byte), psg_count(byte), tempo(byte), multiplier(byte)}`
+- Sets up N FM channels (stride $30) with register assignments from table at $03078C
+- Sets up M PSG channels at A6+$0190
+- If `fm_count == 7`, enables DAC mode (register $2B = $80)
+- Marks conflicting SFX channels for key-off
+
+**SFX instruments ($A0-$D2):** `fm_channel_reg_map_instrument_loader_b` at $030798
+- Uses SFX channel slots at A6+$0220
+- Resolves target via pointer table at $030852
+- Handles PSG noise ($C0 type) with direct writes
+
+**Special SFX ($D6-$D7):** `fm_channel_pointer_table_sfx_loader` at $030892
+- Uses special slots A6+$0340 (DAC) and A6+$0370 (noise)
+- 2 entries in table at $008B921C
+
+### TL Scaling
+
+Table at $031352 (8 bytes, one per algorithm 0-7) determines which operators get volume scaling. This correctly implements YM2612 algorithm-dependent carrier volume control — only output operators are scaled, not modulators.
+
+### Key-On/Off Protocol
+
+- Key-on: write `channel_id | $F0` to register $28 (all 4 operators on)
+- Key-off: write `channel_id | $00` to register $28
+- Panning default: register $B4 = $C0 (stereo center, L+R)
+
+---
+
+## 7. PSG Engine
+
+- 3 tone channels at A6+$0190 (stride $30)
+- 128-entry frequency table at ROM $030FE0 (256 bytes), indexed by note + transpose
+- Volume envelope tables via pointer table at ROM $0329FA
+- Envelope special commands: $80=loop, $81=rewind, $82=set position, $83=reinit
+- Writes: channel_id OR'd with `(volume + $10)`, direct to `$C00011`
+- Noise channel at A6+$0370 uses channel byte from `+$25`
+
+---
+
+## 8. Sequence Engine
+
+Both FM and PSG channels share a byte-stream sequence engine.
+
+### Data Stream Format
+
+Processed per-channel each frame from the pointer at channel+$04:
+
+| Byte Range | Meaning |
+|------------|---------|
+| `$00-$7F` | Duration/rest value |
+| `$80-$DF` | Note-on (stores to +$10, next byte = duration) |
+| `$E0-$FF` | Special command (32-entry jump table at $031094) |
+
+### Special Commands ($E0-$FF)
+
+32 commands dispatched via jump table at $031094:
+
+| Command | Purpose |
+|---------|---------|
+| `$E0` | Set tempo |
+| `$E1` | Set transpose |
+| `$E2` | Set vibrato parameters |
+| `$E3` | Set portamento |
+| `$E4` | Volume adjust |
+| `$E5-$E7` | Envelope, instrument, pitch bend |
+| `$E8-$EF` | Various channel control |
+| `$F0-$FF` | Extended (secondary dispatch at $03111A): Z80 DAC, base frequency, pitch bend direction |
+
+### Sequence Reader Special Bytes (at $0302EE)
+
+| Byte | Effect |
+|------|--------|
+| `$80` | Restart (reset position to 0) |
+| `$81` | Rewind 2 positions |
+| `$82` | Set position from next data byte |
+| `$83` | Reinit (key-on or PSG volume set) |
+| `$84` | Add to pitch multiplier |
+
+### Call/Return Stack
+
+`sequence_call_return_stack` at $031528 supports nested sequence calls. The current sequence pointer (A4) is pushed to the channel struct, a new pointer is loaded, and on return the original is popped. Enables music phrases to be reused across channels.
+
+### Loop Counter
+
+`sequence_loop_counter` at $031528 area supports counted loops within sequences, decrementing a counter and branching back to a stored position.
+
+---
+
+## 9. Fade System
+
+`fm_fade_in_out_proc` at $030D4E — called first in the main tick.
+
+**State machine at A6+$38:**
+- 0 = off (no fade active)
+- 1 = active (fading)
+- 2 = complete
+
+**Separate rates:** DAC (+$39), FM (+$3A), PSG (+$3B). Each frame, the rate is subtracted from (fade out) or added to (fade in) each channel's envelope position.
+
+Set by sequence command via `sequence_fade_rate_set` at $031666.
+
+---
+
+## 10. SFX Priority System
+
+128-byte priority table at ROM $032B30 (one byte per command ID $00-$7F).
+
+`fm_sound_priority_check` at $030536: new commands accepted only if `new_priority >= current_priority`. Values: $80 (highest, most instruments), $7E (SFX), lower values for ambient.
+
+SFX channels (A6+$0220) overlay the music FM channels. When an SFX starts, it saves the music channel state; when SFX ends, music resumes (`fm_channel_resume_panning`).
+
+---
+
+## 11. Z80 DAC Subsystem
+
+### Program Upload
+
+`z80_sound_program_upload_fm_key_on` at $030BF6:
+1. Request Z80 bus, assert Z80 reset
+2. Copy 653 bytes from ROM $031688 → Z80 RAM $A00000
+3. Copy 4096 bytes from ROM $031915 → Z80 RAM $A01000 (DAC samples)
+4. Release Z80 reset (14 NOP delay for stabilization)
+5. Release Z80 bus
+
+### Z80 Program
+
+- Size: 653 bytes ($28D)
+- Location: ROM $031688, uploaded to Z80 $A00000
+- Function: DAC sample playback loop
+- NOT disassembled into Z80 mnemonics (raw dc.w data in `code_30200.asm`)
+- Communication: polls $A00FFD (volume), $A00FFE (sample select), sets $A00FFF bit 7 (busy)
+
+### DAC Sample Data
+
+- Size: 4096 bytes ($1000)
+- Location: ROM $031915, uploaded to Z80 $A01000
+- Format: likely 8-bit unsigned PCM
+
+---
+
+## 12. ROM Data Tables
+
+| ROM Offset | CPU Address | Size | Content |
+|------------|-------------|------|---------|
+| `$030000` | `$008B0000` | 8 | Two entry JMPs |
+| `$030008` | `$008B0008` | ~$AE | Main tick loop |
+| `$030FE0` | `$008B0FE0` | 256 | PSG 128-entry frequency table |
+| `$031352` | `$008B1352` | 8 | TL scaling table (per algorithm) |
+| `$031688` | `$008B1688` | 653 | Z80 DAC program |
+| `$031915` | `$008B1915` | 4096 | DAC sample data |
+| `$032AB8` | `$008B2AB8` | ~124 | Music instrument pointer table ($81-$9F) |
+| `$032B30` | `$008B2B30` | 128 | Priority table (1 byte per command) |
+| `$032936` | `$008B2936` | var | FM sequence pointer table |
+| `$0329FA` | `$008B29FA` | var | PSG envelope data pointer table |
+| `$008B9150` | — | var | SFX instrument pointer table ($A0-$D2) |
+| `$008B921C` | — | var | Special SFX pointer table ($D6-$D7) |
+
+---
+
+## 13. Game Integration
+
+### Data Flow
+
+```
+Game code writes: $C822 (high), $C8A5 (SFX), $C8A4 (low)
+        │
+        ▼
+sound_command_dispatch ($002080)
+  ├── Copies to $8509/$850A (driver state)
+  └── JSR $008B0000
+        │
+        ▼
+sound_driver_tick ($030008)
+  1. Fade processing
+  2. Envelope advance
+  3. Priority check + command dispatch
+  4. Per-channel: sequence → hardware
+     ├── DAC: → Z80 $A00FFD/$A00FFE
+     ├── FM:  → YM2612 $A04000-$A04003
+     └── PSG: → SN76489 $C00011
+  5. RTS
+        │
+        ▼
+audio_frequency_update ($00220C)
+  └── Engine sound pitch calculation (post-driver)
+```
+
+### Command Byte Ranges
+
+| Range | Handler | Purpose |
+|-------|---------|---------|
+| `$00` | $030BF6 | Stop + Z80 reset |
+| `$01-$7F` | $030B90 | Note-on |
+| `$80` | — | Sentinel (no-op) |
+| `$81-$9F` | $03061C | Music instruments (table at $032AB8) |
+| `$A0-$D2` | $030798 | SFX instruments (table at $008B9150) |
+| `$D6-$D7` | $030892 | Special SFX (table at $008B921C) |
+| `$D3-$D5, $D8-$EF` | RTS | Ignored |
+| `$F0` | $030A5C | Full silence + stop |
+| `$F1` | $03094E | Channel stop + SFX cleanup |
+| `$F2` | $0309F2 | Special channel cleanup |
+| `$F3-$FE` | $030B90 | Full driver reset |
+
+### Game-Side RAM Variables
+
+| Address | Purpose |
+|---------|---------|
+| `$C822` | High-priority sound command |
+| `$C823` | Audio trigger flag |
+| `$C8A2` | Tire squeal cooldown timer |
+| `$C8A4` | Low-priority sound command |
+| `$C8A5` | SFX command |
+| `$C8A6` | Last sent SFX B (tracking) |
+| `$C8A7` | Last sent SFX A (de-duplication) |
+| `$8509` | Driver state: Z80 command A |
+| `$850A` | Driver state: Z80 command B |
+| `$8760` | Engine sound: channel A frequency |
+| `$8790` | Engine sound: channel B frequency |

--- a/analysis/TRACK_DATA_FORMAT.md
+++ b/analysis/TRACK_DATA_FORMAT.md
@@ -1,0 +1,309 @@
+# Track Data Format — Virtua Racing Deluxe (32X)
+
+## 1. Overview
+
+The track data system converts 2D world positions into track surface properties (tile type, height, curvature). It uses a **segmented spline model** with paged auxiliary data: 4 data pages spaced $800 bytes apart, segment records of 5 longwords + 9 words, and two table modes (normal/alternate) selected by game mode.
+
+**4 core modules** in `disasm/modules/68k/game/track/`:
+- `track_data_index_calc_table_lookup` — tile address computation (11+ call sites, hot path)
+- `track_data_extract_033` — 4-page geometry extraction
+- `track_segment_load_031` — segment record loader for AI path following
+- `track_graphics_and_sound_loader` — init-only visual asset loading
+
+**Supporting scene modules** handle initialization:
+- `game_mode_track_config` — pre-computes mode/track index variants
+- `scene_dispatch_track_data_setup` — populates segment buffer from ROM tables
+- `scene_camera_init` — sets track data pointer from ROM
+
+---
+
+## 2. Track RAM Variables
+
+| Address | Size | Name | Written By | Read By |
+|---------|------|------|------------|---------|
+| `$C02E` | 24B | work_buffer | track_data_extract_033 | collision system |
+| `$C04C` | word | track_mode | track_segment_load_031 (clears to 0) | — |
+| `$C054` | word | track_pos_hi | track_segment_load_031 | menu segment scroll |
+| `$C056` | word | track_pos_lo | track_segment_load_031 | menu segment scroll |
+| `$C268` | long | track_data_ptr | scene_camera_init (from ROM $00930612) | track_data_extract_033, zone_check_inner |
+| `$C710-$C720` | 20B | segment_data_buf | scene_dispatch_track_data_setup | track_segment_load_031, entity init |
+| `$C734` | long | segment_word_ptr | scene_dispatch_track_data_setup | track_segment_load_031, display list setup |
+| `$C744` | long | segment_table_ptr | scene init (part of $C700+ block) | track_segment_load_031 |
+| `$C89C` | word | game_mode | game_mode_track_config | — |
+| `$C89E` | word | game_mode_x2 | game_mode_track_config | — |
+| `$C8A0` | word | game_mode_x4 | game_mode_track_config | track_data_index_calc |
+| `$C8B0-$C8BA` | 6 words | segment_scroll_vals | menu scroll functions | menu segment add/subtract |
+| `$C8BC` | word | segment_base_index | various | track_segment_load_031 |
+| `$C8C8` | word | track_number | game_mode_track_config | — |
+| `$C8CA` | word | track_x2 | game_mode_track_config | — |
+| `$C8CC` | word | track_x4 | game_mode_track_config | scene_dispatch_track_data_setup, scene_camera_init |
+
+---
+
+## 3. Segment Index Computation
+
+**Function:** `track_data_index_calc_table_lookup`
+**ROM:** $0073E8-$00742C (68 bytes)
+**Source:** [track_data_index_calc_table_lookup.asm](disasm/modules/68k/game/track/track_data_index_calc_table_lookup.asm)
+
+This is the **hot-path function** (11+ call sites per frame) that converts 2D position into a track tile address.
+
+**Algorithm:**
+```
+Input: D1 = X component, D2 = Y component, A0+$E4 = table select flag
+Output: A1 = pointer to track tile data
+
+D3 = $400                         // base offset (center of track grid)
+D4 = D1 >> 4                     // scale X
+D4 = D4 + D3                     // offset from center
+D4 = D4 >> 5                     // column index (32-unit grid cells)
+D5 = D2 >> 4                     // scale Y
+D3 = D3 + D5                     // row offset
+D3 = D3 & $FFE0                  // align to 32-byte boundary
+D3 = D3 << 1                     // scale for word entries
+D3 = D3 + D4                     // combine row + column
+D3 = D3 + D3                     // ×2 for word-sized table entries
+
+// Select pointer table based on game mode and table flag:
+D0 = [$C8A0] × 2                 // game_mode × 8 (already ×4, doubled)
+if A0+$E4 == 0:
+    A2 = normal_table @ $00742C
+else:
+    A2 = alternate_table @ $00745C
+
+// Two-level lookup:
+A1 = [A2 + D0]                   // segment_map_ptr (longword from table)
+D3 = [A1 + D3]                   // word offset from segment map
+A1 = [A2 + D0 + 4]               // base_data_ptr (longword from table)
+D3 = D3 × 2                      // scale offset
+A1 = A1 + D3                     // final tile data address
+```
+
+**Inline ROM Tables (96 bytes total at $00742C-$00748B):**
+
+Normal table at $00742C — 6 longword pairs (one per game mode × 2):
+```
+Mode 0: segment_map = $0094C000, base_data = $00970000
+Mode 1: segment_map = $0094C000, base_data = $00970000  (same)
+Mode 2: ...
+```
+
+Alternate table at $00745C — same format, mostly zeroed for unused modes.
+
+**Callers (11 sites):**
+- `track_boundary_collision_detection`: 5 calls (center + 4 probes)
+- `directional_collision_probe`: 3 calls (forward, adjacent, center)
+- `visibility_eval_caller`: 1 call
+- `race_init_orch_005`: 1 call
+
+---
+
+## 4. Segment Data Layout
+
+**Function:** `track_segment_load_031`
+**ROM:** $00B990-$00BA18 (136 bytes)
+**Source:** [track_segment_load_031.asm](disasm/modules/68k/game/track/track_segment_load_031.asm)
+
+Loads a complete segment record into an output buffer (A2). Used by AI path-following code.
+
+**Algorithm:**
+```
+Input: D0 = segment offset, A2 = output buffer
+Reads: $C744 (table ptr), $C8BC (base index), $C303 (sub-index)
+
+A1 = [$C744]                     // segment table base
+D0 = D0 + [$C8BC]                // add base index
+A1 = [A1 + D0]                   // dereference to segment entry
+sub_idx = [$C303] × 4            // sub-index (longword stride)
+position = [A1 + sub_idx]        // position longword
+$C054 = position.hi              // track_pos_hi
+$C056 = position.lo              // track_pos_lo
+
+// Copy 5 longwords from segment data buffer:
+A2[$10] = [$C710]
+A2[$24] = [$C714]
+A2[$38] = [$C718]
+A2[$4C] = [$C71C]
+A2[$60] = [$C720]
+
+// Copy 9 words from segment word pointer:
+A1 = [$C734]
+A2[$16,$18,$1A] = (A1)[0,1,2]    // 3 words
+A2[$2A,$2C,$2E] = (A1)[3,4,5]    // 3 words
+A2[$3E,$40,$42] = (A1)[6,7,8]    // 3 words
+
+// Initialize 5 counters to 1:
+A2[$00] = A2[$14] = A2[$28] = A2[$3C] = A2[$50] = 1
+$C04C = 0                        // clear track_mode
+```
+
+**Output buffer stride pattern** (5 sub-segments, 20 bytes apart):
+
+| Sub-Seg | Counter | Longword | Words (3) |
+|---------|---------|----------|-----------|
+| 0 | A2+$00 | A2+$10 | A2+$16, $18, $1A |
+| 1 | A2+$14 | A2+$24 | A2+$2A, $2C, $2E |
+| 2 | A2+$28 | A2+$38 | A2+$3E, $40, $42 |
+| 3 | A2+$3C | A2+$4C | (no words for sub-seg 3) |
+| 4 | A2+$50 | A2+$60 | (no words for sub-seg 4) |
+
+**Callers:** `ai_timer_dec_cond_state_clear.asm:16`, `ai_timer_dec_state_clear_reactivate.asm:16`
+
+---
+
+## 5. Multi-Page Data Extraction
+
+**Function:** `track_data_extract_033`
+**ROM:** $0076A2-$007700 (94 bytes)
+**Source:** [track_data_extract_033.asm](disasm/modules/68k/game/track/track_data_extract_033.asm)
+
+Extracts signed byte pairs from 4 pages of 3D track geometry data. Each page is $800 bytes (2KB) from the previous, containing curvature/normal/gradient data per segment.
+
+**Algorithm:**
+```
+Input: D0 = track segment index (pre-shifted)
+Reads: $C268 (track_data_ptr)
+Writes: work buffer at $C02E (24 bytes)
+
+A1 = [$C268]                     // track data base
+offset = (D0 >> 6) × 2           // segment stride
+A1 = A1 + offset
+
+// Page 0:
+$C02E+$00 = sign_extend(A1[0])   // signed byte → word
+$C02E+$04 = sign_extend(A1[1])
+
+// Page 1 (A1 += $7FF):
+$C02E+$06 = sign_extend(A1[0])
+$C02E+$0A = sign_extend(A1[1])
+
+// Page 2 (A1 += $7FF):
+$C02E+$0C = sign_extend(A1[0])
+$C02E+$10 = sign_extend(A1[1])
+
+// Page 3 (A1 += $7FF):
+$C02E+$12 = sign_extend(A1[0])
+$C02E+$16 = sign_extend(A1[1])
+```
+
+The `$7FF` increment (not $800) accounts for the `(A1)+` post-increment on the first byte read of each pair.
+
+**Work buffer layout at $C02E:**
+
+| Offset | Page | Byte | Likely Meaning |
+|--------|------|------|----------------|
+| +$00 | 0 | 0 | Curvature X |
+| +$04 | 0 | 1 | Curvature Y |
+| +$06 | 1 | 0 | Normal X |
+| +$0A | 1 | 1 | Normal Y |
+| +$0C | 2 | 0 | Gradient X |
+| +$10 | 2 | 1 | Gradient Y |
+| +$12 | 3 | 0 | Reserved X |
+| +$16 | 3 | 1 | Reserved Y |
+
+**Caller:** `track_boundary_collision_detection` at $0078A8
+
+---
+
+## 6. Track Graphics and Sound Loading
+
+**Function:** `track_graphics_and_sound_loader`
+**ROM:** $00C7C2-$00C8E6 (292 bytes)
+**Source:** [track_graphics_and_sound_loader.asm](disasm/modules/68k/game/track/track_graphics_and_sound_loader.asm)
+
+Init-only function with two entry points. Loads track-specific visual assets and palette data during scene setup.
+
+**Entry 1 (main, $00C7C2):**
+- Loads from ROM tables at `$0089B6AC` / `$0089B73C` indexed by track
+- Copies 54 longwords (216 bytes) of palette data
+- Initializes 10+ sound/timing state variables
+- Calls sound driver
+
+**Entry 2 (+$AE = $00C870):**
+- Loads track overlay graphics from 3 ROM tables:
+  - `$00895488` (normal modes)
+  - `$008954F4` (mode-specific)
+  - `$00895560` (alternate mode)
+- All indexed by `$C89C` (game_mode)
+- Configures display viewport
+- Clears display list at `$FF60C0-$FF60D0`
+
+**Callers (5 sites):** All `race_scene_init_*` modules
+
+---
+
+## 7. Initialization Data Flow
+
+```
+game_mode_track_config (D0=mode, D1=track)
+  → $C89C/C89E/C8A0 = mode, ×2, ×4
+  → $C8C8/C8CA/C8CC = track, ×2, ×4
+  → $C826 = multiplayer flag
+        |
+        v
+scene_camera_init (uses $C8CC)
+  → $C268 = track_data_ptr (from ROM $00930612)
+  → $C700+ region populated (includes $C710, $C734, $C744)
+        |
+        v
+scene_dispatch_track_data_setup (uses $C8CC)
+  → $C710 = segment data buffer (from ROM $008957A0/$008956C8)
+  → 4 display list blocks at $FF6114/$FF6218/$FF6344/$FF6448
+        |
+        v
+track_graphics_and_sound_loader (uses $C89C)
+  → Palette data (54 longs)
+  → Overlay graphics
+  → Display list at $FF60C0-$FF60D0
+```
+
+**Runtime hot path:**
+```
+track_data_index_calc_table_lookup (×11/frame)
+  Position → tile address via $C8A0 + ROM pointer tables
+
+track_data_extract_033 (×1/frame via collision)
+  Tile → 4-page geometry extraction to $C02E work buffer
+
+track_segment_load_031 (called by AI)
+  $C744 table + $C8BC index → 5L+9W segment record
+```
+
+---
+
+## 8. Per-Track ROM Data Tables
+
+| ROM Address | Purpose | Indexed By |
+|-------------|---------|------------|
+| `$00742C` | Normal segment map/base pointer pairs (inline) | `$C8A0` (mode×4, doubled) |
+| `$00745C` | Alternate segment map/base pointer pairs (inline) | `$C8A0` |
+| `$00930612` | Track data base pointers (road geometry) | `$C8CC` (track×4) |
+| `$0094C000` | Segment map (tile grid → offset lookup) | Computed 2D index |
+| `$00970000` | Base track data (tile properties) | Offset from segment map |
+| `$008957A0` | Track segment base table | `$C8CC` |
+| `$008956C8` | Track segment alt table | `$C8CC` |
+| `$0089B6AC` | Track graphics data | Track index |
+| `$0089B73C` | Track palette data (54 longs per track) | Track index |
+| `$00895488` | Overlay graphics (normal) | `$C89C` (mode) |
+| `$008954F4` | Overlay graphics (mode-specific) | `$C89C` |
+| `$00895560` | Overlay graphics (alternate) | `$C89C` |
+| `$0129E0-$012A1F` | Per-track parameter tables (3 × 16 words) | Track index |
+
+---
+
+## 9. Menu Track Segment System
+
+A parallel subsystem manages 6 scroll accumulators for menu/UI track preview:
+
+| Seg | Value | Accumulator | Add Func | Sub Func |
+|-----|-------|-------------|----------|----------|
+| 0 | `$C8B0` | `$C056` | $01474A | $014754 |
+| 1 | `$C8B2` | `$C086` | $01475E | $014768 |
+| 2 | `$C8B4` | `$C0B0` | $014772 | $01477C |
+| 3 | `$C8B6` | `$C0AE` | $014786 | $014790 |
+| 4 | `$C8B8` | `$C0B2` | $01479A | $0147A4 |
+| 5 | `$C8BA` | `$C054` | $0147AE | $0147B8 |
+
+All initialized to `$0080` by `initialize_track_segment_values_to_center` at $0147E8.
+
+**Note:** Segments 0 and 5 share `$C054`/`$C056` with the race-mode track position system. These are only used during menu display, not during racing.


### PR DESCRIPTION
Seven new architecture documents covering the game logic subsystems that are not yet documented in analysis/. These complement the existing SCENE_HANDLER_ARCHITECTURE, VINT_HANDLER_ARCHITECTURE, RENDERING_PIPELINE, and SH2 deep-dive docs by covering what runs above the renderer.

- ENTITY_OBJECT_ARCHITECTURE.md: Dual-layer 68K↔SH2 design. 4 WRAM tables ($FF9000–$FF9FFF, 256B fixed-stride records), 20-subroutine per-frame pipeline, display object array at $FF6218 (60B stride × 15 entries), 2560-byte DMA burst to SH2 SDRAM. 46 modules.

- PHYSICS_SYSTEM_ARCHITECTURE.md: 17-step per-frame pipeline. 8.8 fixed-point grip ($0100 = 1.0), 7-gear transmission with multiplicative ratio table, force integration with drag/friction/air resistance, dual drift variants (A and B). Documents the JMP fall-through from entity_pos_update directly into the collision system (no RTS boundary). 51 modules, ~4.5KB.

- COLLISION_SYSTEM_ARCHITECTURE.md: Three subsystems — track boundary (center + 4 directional probes, 4-iteration binary search, EMA surface tracking at alpha=0.5), object-to-object (weighted speed averaging), and proximity zones (4-level Manhattan distance). Documents the same-tile shortcut optimisation in track_boundary_collision_detection. 23 modules.

- AI_SYSTEM_ARCHITECTURE.md: 15-state machine (120-frame timer, cyclic 3-phase pattern), 4-slot race position system, 3-band Manhattan distance collision avoidance, 4-band spawn approach ramp, atan2 heading approximation. Covers the collision_avoidance_speed_calc fall-through into physics_integration (no RTS). 27 modules, ~2.5KB.

- TRACK_DATA_FORMAT.md: Segmented spline model with 4 data pages spaced $800B apart. Documents the 2-level ROM table lookup, work buffer at $C02E shared between track extraction and collision, and the 3 scene-init functions that pre-populate the segment buffer.

- MEMORY_MANAGEMENT_ARCHITECTURE.md: Full WRAM region map ($FF0000–$FFFFFF). No dynamic allocation anywhere in the game. Documents the JSR-cascade fill and copy primitives ("waterfall" technique) at $004836–$004996, the MOVEM block copier with SH2 busy-guard, and the 16-bit PRNG.

- SOUND_DRIVER_ARCHITECTURE.md: 68K-resident tick-based sequencer — NOT Z80 driven. 18 channels (1 DAC + 6 FM + 3 PSG + 6 SFX overlay + 2 special), $30-byte channel structs. YM2612, SN76489, and Z80 DAC (653-byte program) hardware interfaces. 32 special sequencer commands. ROM $030000–$034200, RAM $FF8500–$FF8890. 95 modules across sound/ and game/sound/.